### PR TITLE
fix: read from /dev/tty so curl | bash works interactively

### DIFF
--- a/woltspace
+++ b/woltspace
@@ -190,7 +190,7 @@ if [ "$cmd" = "init" ]; then
   printf "  %b\n\n" "${_D}\"how much wolt could a wolt chuck chuck\n   if a wolt chuck could chuck wolt?\"${_R}"
 
   echo -n "  name your wolt: "
-  read NAME
+  read NAME </dev/tty
 
   if [ -z "$NAME" ]; then
     echo "error: name is required"
@@ -217,7 +217,7 @@ if [ "$cmd" = "init" ]; then
   printf "  %bwhere your wolt can gnaw freely. your wolts will persist at %b%s%b\n" "${_D}" "${_R}${_C}" "$WOLTS_DIR" "${_R}"
   echo ""
   echo -n "  ${_C}continue? [Y/n]${_R} "
-  read -r CONFIRM
+  read -r CONFIRM </dev/tty
   CONFIRM="${CONFIRM:-Y}"
   if [[ "$CONFIRM" != [Yy] ]]; then
     echo ""


### PR DESCRIPTION
read NAME and read CONFIRM were getting EOF when stdin was a pipe, causing silent exit after the splash screen.