### PR TITLE
feat: support permanent Cloudflare tunnels via custom domains

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -158,24 +158,41 @@ rm -f "$WOLTS_DIR/.state/tunnel-url" "$WOLT_DIR/.state/tunnel-url"
 TUNNEL_PID=""
 
 if [ "${ENABLE_TUNNEL:-true}" != "false" ]; then
-  echo "opening tunnel..."
   TUNNEL_LOG="$WOLTS_DIR/.state/tunnel.log"
 
-  cloudflared tunnel --url http://localhost:3000 > "$TUNNEL_LOG" 2>&1 &
-  TUNNEL_PID=$!
+  if [ -n "${CF_TUNNEL_TOKEN:-}" ]; then
+    # Managed tunnel: permanent domain via Cloudflare dashboard
+    echo "starting managed tunnel → ${CF_TUNNEL_HOSTNAME:-<no hostname configured>}..."
+    cloudflared tunnel run --token "$CF_TUNNEL_TOKEN" > "$TUNNEL_LOG" 2>&1 &
+    TUNNEL_PID=$!
 
-  # Wait for tunnel URL (blocks until found, max 30s)
-  for i in $(seq 1 30); do
-    URL=$(grep -o 'https://[^ ]*trycloudflare.com' "$TUNNEL_LOG" 2>/dev/null | head -1)
-    if [ -n "$URL" ]; then
-      echo "$URL" > "$WOLTS_DIR/.state/tunnel-url"
-      # Also write to active wolt for backward compat (CLI reads it)
-      echo "$URL" > "$WOLT_DIR/.state/tunnel-url"
-      echo "tunnel ready: $URL"
-      break
+    if [ -n "${CF_TUNNEL_HOSTNAME:-}" ]; then
+      TUNNEL_URL="https://${CF_TUNNEL_HOSTNAME}"
+      echo "$TUNNEL_URL" > "$WOLTS_DIR/.state/tunnel-url"
+      echo "$TUNNEL_URL" > "$WOLT_DIR/.state/tunnel-url"
+      echo "tunnel ready: $TUNNEL_URL (permanent)"
+    else
+      echo "warning: CF_TUNNEL_TOKEN set but CF_TUNNEL_HOSTNAME missing — tunnel-url not written"
     fi
-    sleep 1
-  done
+
+  else
+    # Quick tunnel: ephemeral *.trycloudflare.com URL (default)
+    echo "opening tunnel..."
+    cloudflared tunnel --url http://localhost:3000 > "$TUNNEL_LOG" 2>&1 &
+    TUNNEL_PID=$!
+
+    # Wait for tunnel URL (blocks until found, max 30s)
+    for i in $(seq 1 30); do
+      URL=$(grep -o 'https://[^ ]*trycloudflare.com' "$TUNNEL_LOG" 2>/dev/null | head -1)
+      if [ -n "$URL" ]; then
+        echo "$URL" > "$WOLTS_DIR/.state/tunnel-url"
+        echo "$URL" > "$WOLT_DIR/.state/tunnel-url"
+        echo "tunnel ready: $URL"
+        break
+      fi
+      sleep 1
+    done
+  fi
 else
   echo "tunnel disabled — access via http://localhost:4444"
 fi

--- a/container/skills/setup-tunnel/SKILL.md
+++ b/container/skills/setup-tunnel/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: setup-tunnel
+description: Set up a permanent Cloudflare tunnel with a custom domain — or check/manage your current tunnel config.
+user_invocable: true
+---
+
+# Setup Tunnel — Permanent Domain
+
+Guide the human through upgrading from an ephemeral `*.trycloudflare.com` tunnel to a permanent domain via Cloudflare. Step by step, one at a time.
+
+The goal: their wolt gets a stable URL that survives restarts. No more random URLs.
+
+## Important: Read this fully before responding
+
+This is a guided conversation. Go step by step, one exchange at a time. Wait for the human to respond before moving on. Be concise — they're probably reading this on their phone.
+
+## Step 0: Check current state
+
+Before starting, check what's already configured:
+
+```bash
+# Check for existing tunnel config
+grep -E '^CF_TUNNEL_TOKEN=|^CF_TUNNEL_HOSTNAME=' .env 2>/dev/null
+```
+
+If permanent tunnel vars already exist, tell the human what's configured and ask what they want to do:
+- Test the connection
+- Change the domain
+- Switch back to ephemeral
+- View current tunnel status
+
+If nothing's configured, proceed to Step 1.
+
+## Step 1: Prerequisites
+
+Tell the human:
+
+> You'll need two things:
+> 1. A **Cloudflare account** (free tier works) — https://dash.cloudflare.com/sign-up
+> 2. A **domain on Cloudflare** — either buy one there or transfer an existing domain's DNS to Cloudflare
+>
+> Got both? Paste the domain you want to use (e.g. `nw.yourdomain.com`).
+
+Wait for their response. Save the hostname they give you — you'll need it later.
+
+If they don't have a domain yet, point them to Cloudflare Registrar (cheapest option, no markup) or explain they can transfer an existing domain's nameservers to Cloudflare.
+
+## Step 2: Create the tunnel in Cloudflare dashboard
+
+Tell the human:
+
+> Head to the **Cloudflare Zero Trust dashboard**:
+> https://one.dash.cloudflare.com/
+>
+> Then: **Networks** > **Tunnels** > **Create a tunnel**
+>
+> 1. Choose **Cloudflared** as the connector type
+> 2. Name it whatever you want (e.g. your wolt's name)
+> 3. On the "Install connector" page — **don't install anything**. Just copy the **token** from the install command. It's the long string after `--token` in the command they show you. Looks like `eyJ...`
+> 4. On the "Route tunnel" page, add a **public hostname**:
+>    - Subdomain: the one you chose (e.g. `nw`)
+>    - Domain: your Cloudflare domain
+>    - Service type: **HTTP**
+>    - Service URL: `localhost:3000`
+> 5. Save the tunnel.
+>
+> Paste the token here when you have it.
+
+Wait for the token. It should start with `eyJ` (base64 JSON). Validate it looks reasonable.
+
+## Step 3: Configure env vars
+
+Once you have the token and hostname, add them to `.env`:
+
+```bash
+# Read current .env to avoid overwriting
+cat .env
+```
+
+Then append the tunnel config:
+
+```
+CF_TUNNEL_TOKEN=<their token>
+CF_TUNNEL_HOSTNAME=<their hostname, e.g. nw.example.com>
+```
+
+Use the Edit tool to add these to `.env`. Place them near the top, after any existing tunnel-related vars. Add a comment:
+
+```
+# Permanent tunnel — custom domain via Cloudflare managed tunnel
+CF_TUNNEL_TOKEN=eyJ...
+CF_TUNNEL_HOSTNAME=nw.example.com
+```
+
+## Step 4: Update entrypoint (if needed)
+
+Check if the entrypoint already supports `CF_TUNNEL_TOKEN`. Look at the tunnel startup section:
+
+```bash
+grep -n 'CF_TUNNEL_TOKEN' container/entrypoint.sh 2>/dev/null || grep -n 'CF_TUNNEL_TOKEN' /workspace/woltspace/container/entrypoint.sh 2>/dev/null
+```
+
+If the three-tier tunnel logic is NOT yet in the entrypoint, apply it. The tunnel startup section (look for `cloudflared tunnel`) should become:
+
+```bash
+if [ "${ENABLE_TUNNEL:-true}" != "false" ]; then
+  TUNNEL_LOG="$WOLTS_DIR/.state/tunnel.log"
+
+  if [ -n "${CF_TUNNEL_TOKEN:-}" ]; then
+    # Managed tunnel: permanent domain via Cloudflare dashboard
+    echo "starting managed tunnel → ${CF_TUNNEL_HOSTNAME:-<no hostname configured>}..."
+    cloudflared tunnel run --token "$CF_TUNNEL_TOKEN" > "$TUNNEL_LOG" 2>&1 &
+    TUNNEL_PID=$!
+
+    if [ -n "${CF_TUNNEL_HOSTNAME:-}" ]; then
+      TUNNEL_URL="https://${CF_TUNNEL_HOSTNAME}"
+      echo "$TUNNEL_URL" > "$WOLTS_DIR/.state/tunnel-url"
+      [ -d "$WOLT_DIR/.state" ] && echo "$TUNNEL_URL" > "$WOLT_DIR/.state/tunnel-url"
+      echo "tunnel ready: $TUNNEL_URL (permanent)"
+    else
+      echo "warning: CF_TUNNEL_TOKEN set but CF_TUNNEL_HOSTNAME missing — tunnel-url not written"
+    fi
+
+  else
+    # Quick tunnel: ephemeral *.trycloudflare.com URL (default)
+    echo "opening tunnel..."
+    cloudflared tunnel --url http://localhost:3000 > "$TUNNEL_LOG" 2>&1 &
+    TUNNEL_PID=$!
+
+    for i in $(seq 1 30); do
+      URL=$(grep -o 'https://[^ ]*trycloudflare.com' "$TUNNEL_LOG" 2>/dev/null | head -1)
+      if [ -n "$URL" ]; then
+        echo "$URL" > "$WOLTS_DIR/.state/tunnel-url"
+        [ -d "$WOLT_DIR/.state" ] && echo "$URL" > "$WOLT_DIR/.state/tunnel-url"
+        echo "tunnel ready: $URL"
+        break
+      fi
+      sleep 1
+    done
+  fi
+else
+  echo "tunnel disabled — access via http://localhost:4444"
+fi
+```
+
+Apply this to whichever entrypoint is active:
+- `/workspace/woltspace/container/entrypoint.sh` (platform — preferred)
+- `container/entrypoint.sh` (wolt-local, if it exists and is used)
+
+## Step 5: Test
+
+Tell the human:
+
+> The config is set. To activate it, the container needs to restart:
+> ```
+> woltspace restart
+> ```
+> Once it's back up, the tunnel should connect to your permanent domain. Try opening `https://<their hostname>` in a browser.
+
+If they're running the neowolt standalone container (not woltspace), the command is:
+```
+./tunnel.sh --rebuild
+```
+
+After restart, verify:
+```bash
+cat .state/tunnel-url
+```
+
+It should show `https://<their hostname>` instead of a random trycloudflare.com URL.
+
+## Step 6: Verify DNS
+
+If the site doesn't load after restart, check:
+
+1. **Cloudflare dashboard** — is the tunnel showing as "Healthy"?
+2. **DNS** — does the CNAME exist? Cloudflare should have created it automatically when they routed the tunnel.
+3. **Logs** — `cat .state/tunnel.log` for errors (auth failures, token issues)
+
+Common issues:
+- Token expired → regenerate in dashboard
+- Wrong hostname → check the public hostname config in the tunnel settings
+- DNS propagation → wait a few minutes if the domain was just added
+
+## Reverting to ephemeral
+
+If they want to go back:
+
+```bash
+# Comment out or remove from .env:
+# CF_TUNNEL_TOKEN=...
+# CF_TUNNEL_HOSTNAME=...
+```
+
+Then restart. Without those vars, the entrypoint falls back to a quick tunnel automatically.
+
+## Summary of env vars
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `CF_TUNNEL_TOKEN` | For permanent | Token from Cloudflare dashboard (Tunnels > Install connector) |
+| `CF_TUNNEL_HOSTNAME` | For permanent | Your domain (e.g. `nw.example.com`) |
+| `ENABLE_TUNNEL` | No | Set to `false` to disable tunnels entirely (default: `true`) |


### PR DESCRIPTION
## Summary

- Adds three-tier tunnel detection in `container/entrypoint.sh`: managed tunnel (permanent domain) when `CF_TUNNEL_TOKEN` is set, otherwise falls back to ephemeral quick tunnel (current behavior)
- Adds `/setup-tunnel` skill that walks users through the entire Cloudflare setup interactively
- Zero regression — no env vars set = exact same behavior as before

## How to set up a permanent domain (beginner guide)

### What you need
- A free [Cloudflare account](https://dash.cloudflare.com/sign-up)
- A domain on Cloudflare (buy one there ~$10/yr, or transfer existing DNS)

### Steps

1. Go to the **Cloudflare Zero Trust dashboard**: https://one.dash.cloudflare.com/
2. Navigate to **Networks** → **Tunnels** → **Create a tunnel**
3. Choose **Cloudflared** as the connector type
4. Name it whatever you want (e.g. your wolt's name)
5. On the "Install connector" page — **don't install anything**. Just copy the **token** — it's the long `eyJ...` string after `--token` in the install command they show you
6. Click next. On **Route tunnel** → Add a public hostname:
   - **Subdomain**: whatever you want (e.g. `nw`)
   - **Domain**: pick your Cloudflare domain from the dropdown
   - **Service type**: HTTP
   - **URL**: `localhost:3000`
7. Save the tunnel
8. Add two lines to your wolt's `.env`:
   ```
   CF_TUNNEL_TOKEN=eyJ...your-token-here
   CF_TUNNEL_HOSTNAME=nw.yourdomain.com
   ```
9. Restart: `woltspace restart`
10. Visit `https://nw.yourdomain.com` — your wolt now has a permanent URL that survives restarts

### Or just use the skill

Run `/setup-tunnel` inside any wolt session — it walks you through every step interactively and configures everything for you.

### How it works

The entrypoint checks for `CF_TUNNEL_TOKEN` at startup:
- **Token present** → runs `cloudflared tunnel run --token` (permanent domain, URL written instantly)
- **No token** → runs `cloudflared tunnel --url` (ephemeral `*.trycloudflare.com`, current default)

Everything downstream (bot links, split view, CLI) reads `.state/tunnel-url` — no changes needed. The file just contains a stable URL instead of a random one.

### Reverting to ephemeral

Remove or comment out `CF_TUNNEL_TOKEN` and `CF_TUNNEL_HOSTNAME` from `.env`, restart. Falls back automatically.

## Test plan

- [ ] Start without `CF_TUNNEL_TOKEN` — verify ephemeral tunnel works as before
- [ ] Set `CF_TUNNEL_TOKEN` + `CF_TUNNEL_HOSTNAME` — verify permanent domain connects
- [ ] Check `.state/tunnel-url` contains the permanent hostname
- [ ] Verify bot session links use the permanent URL
- [ ] Remove the vars, restart — confirm fallback to ephemeral

🤖 Generated with [Claude Code](https://claude.com/claude-code)