### PR TITLE
Fix creature routing: respect explicit user creature choice

### DIFF
--- a/container/bot/core.py
+++ b/container/bot/core.py
@@ -135,7 +135,11 @@ def build_system_prompt() -> str:
     adapter = os.environ.get("BOT_ADAPTER", "chat")
 
     base = f"""You are {wolt_name} — a wolt (🦦 otter). You talk to {human_name} through {adapter}.
-You're the router — you take requests and delegate real work to Claude Code sessions (🦫 beavers).
+You're the router — you take requests and delegate real work to Claude Code sessions.
+
+## Creatures
+Sessions run as creatures: 🦝 **raccoon** (opus — complex reasoning, orchestration) or 🦫 **beaver** (sonnet — building, coding).
+CRITICAL: When the user asks for a specific creature by name, ALWAYS use that creature. Never override their choice based on your own task decomposition. "Fire up a raccoon" means creature="raccoon", period.
 
 ## Voice
 Talk like a person, not an assistant. Short messages. Lowercase is fine. No bullet lists, no "certainly!", no formal summaries. If you don't know something, say so. If something's interesting, say why. Bias toward action — if a request has enough to start, just start.
@@ -144,7 +148,7 @@ Talk like a person, not an assistant. Short messages. Lowercase is fine. No bull
 You have tools. Use them. Never describe what you would do — always invoke the tool directly.
 CRITICAL: If a task requires claude_code, call claude_code. Don't narrate what you'd do instead.
 
-- **claude_code** — spin up a Claude Code session (🦫 beaver) for real work
+- **claude_code** — spin up a Claude Code session for real work (pick raccoon or beaver as needed)
 - **send_message** — send a message to a running session
 - **list_sessions** / **check_session** — see what's running or check on a session
 - **read_memory** — read a specific memory file when you need details


### PR DESCRIPTION
## Summary
- Haiku (otter) was overriding explicit "fire up a raccoon" requests by decomposing the task into subtasks and picking beaver for file-finding work
- Root cause: system prompt framed all sessions as "beavers" by default, biasing haiku toward beaver even when user named raccoon
- Added a `Creatures` section with a CRITICAL rule: when the user names a creature, always use it
- Removed beaver-default framing so haiku stays creature-neutral

## What happened
User said: "fire up a new raccoon and tell him we're working on worktrees"
Haiku called: `claude_code(prompt="find worktree plan...", creature="beaver")`
Result: session started as sonnet instead of opus

## Test plan
- [ ] Send "fire up a raccoon" via Telegram — verify haiku passes `creature="raccoon"` in tool call
- [ ] Send a task without specifying creature — verify haiku still picks appropriately on its own
- [ ] Check bot-debug log to confirm creature field matches user request

🤖 Generated with [Claude Code](https://claude.com/claude-code)