### PR TITLE
fix: session revival picks correct conversation

### DIFF
--- a/container/bin/run-session.sh
+++ b/container/bin/run-session.sh
@@ -17,6 +17,10 @@ SESSION_REG="$SCRIPT_DIR/session-reg"
 cd "$WORK_DIR"
 export WOLT_SESSION="$SESSION_NAME"
 
+# Generate a stable Claude session ID so we can --resume the right conversation later
+CLAUDE_SESSION_ID=$(python3 -c "import uuid; print(uuid.uuid4())")
+$SESSION_REG update "$SESSION_NAME" "claude_session_id=$CLAUDE_SESSION_ID" > /dev/null 2>&1 || true
+
 # Generate a short descriptive title from the prompt (first line, ~60 chars, clean)
 TITLE=$(python3 -c "
 import re, sys
@@ -84,7 +88,7 @@ MODEL_FLAG=""
 if [ -n "$MODEL" ]; then
     MODEL_FLAG="--model $MODEL"
 fi
-claude --dangerously-skip-permissions $MODEL_FLAG "$FULL_PROMPT" || EXIT_CODE=$?
+claude --dangerously-skip-permissions --session-id "$CLAUDE_SESSION_ID" $MODEL_FLAG "$FULL_PROMPT" || EXIT_CODE=$?
 
 # Update registry with final status
 $SESSION_REG finish "$SESSION_NAME" "$EXIT_CODE" > /dev/null 2>&1 || true

--- a/container/bot/core.py
+++ b/container/bot/core.py
@@ -534,13 +534,22 @@ def message_session(session_name: str, text: str) -> dict:
         except subprocess.CalledProcessError as e:
             return {"ok": False, "error": f"tmux send-keys failed: {e}", "session": safe, "url": session_url}
 
-    # Claude exited — restart with --continue and deliver the message as the new prompt
+    # Claude exited — restart with --resume (specific session ID) or --continue (fallback)
     _bot_log("session_revive", {"session": safe, "text": text[:200]})
     try:
-        resume_cmd = f"export WOLT_SESSION={shlex.quote(safe)} && claude --dangerously-skip-permissions --continue {shlex.quote(text)}"
+        # Try to get the Claude session UUID from the registry so we resume the right conversation
+        reg_data = registry.get(safe, check_alive=False)
+        claude_session_id = reg_data.get("claude_session_id") if reg_data else None
+        if claude_session_id:
+            resume_flag = f"--resume {shlex.quote(claude_session_id)}"
+        else:
+            # Fallback for sessions started before this fix
+            resume_flag = "--continue"
+        _bot_log("session_revive_method", {"session": safe, "claude_session_id": claude_session_id or "none", "method": "resume" if claude_session_id else "continue"})
+        resume_cmd = f"export WOLT_SESSION={shlex.quote(safe)} && claude --dangerously-skip-permissions {resume_flag} {shlex.quote(text)}"
         subprocess.run(["tmux", "send-keys", "-t", safe, "-l", resume_cmd], check=True)
         subprocess.run(["tmux", "send-keys", "-t", safe, "", "Enter"], check=True)
-        return {"ok": True, "session": safe, "url": session_url, "status": "revived", "detail": "Claude had exited — restarted with --continue and delivered message"}
+        return {"ok": True, "session": safe, "url": session_url, "status": "revived", "detail": f"Claude had exited — restarted with {'--resume ' + claude_session_id if claude_session_id else '--continue'} and delivered message"}
     except subprocess.CalledProcessError as e:
         return {"ok": False, "error": f"session revive failed: {e}", "session": safe, "url": session_url}
 

--- a/test/test_closed_loop.py
+++ b/test/test_closed_loop.py
@@ -460,6 +460,97 @@ class TestRegressions:
         assert sentinel in server_src
         assert sentinel in adapter_src
 
+    @requires_tmux
+    def test_revival_picks_correct_session(self, tmp_path):
+        """Reviving session A must --resume A's UUID, not B's (the most recent).
+
+        Bug: message_session used --continue which picks the most recent
+        conversation in the directory. When multiple sessions share a dir,
+        this revives the wrong one. Fix: use --resume <uuid> from registry.
+        """
+        import bot.core as core
+        from sessions import SessionRegistry
+
+        # Use a temp registry so we don't pollute real state
+        tmp_reg = SessionRegistry(tmp_path / "registry")
+        original_reg = core.registry
+        core.registry = tmp_reg
+
+        session_a = f"test-revival-a-{int(time.time()) % 100000}"
+        session_b = f"test-revival-b-{int(time.time()) % 100000}"
+        uuid_a = "aaaaaaaa-1111-2222-3333-444444444444"
+        uuid_b = "bbbbbbbb-1111-2222-3333-444444444444"
+
+        try:
+            # Create registry entries with distinct claude_session_ids
+            tmp_reg.create(session_a, wolt="neowolt")
+            tmp_reg.update(session_a, claude_session_id=uuid_a)
+            tmp_reg.create(session_b, wolt="neowolt")
+            tmp_reg.update(session_b, claude_session_id=uuid_b)
+
+            # Create tmux sessions running bash (no claude → _session_has_claude returns False)
+            for name in [session_a, session_b]:
+                subprocess.run(["tmux", "new-session", "-d", "-s", name, "bash"], check=True)
+            time.sleep(0.3)
+
+            # Revive session A — should use --resume uuid_a
+            result = core.message_session(session_a, "test message")
+            assert result["ok"] is True
+            assert result["status"] == "revived"
+            assert uuid_a in result.get("detail", ""), (
+                f"Expected --resume {uuid_a} in detail, got: {result.get('detail')}"
+            )
+            assert uuid_b not in result.get("detail", ""), (
+                f"Should NOT contain session B's UUID: {result.get('detail')}"
+            )
+
+            # Verify the actual command sent to tmux contains --resume with the right UUID
+            # (tmux may line-wrap, so join all lines before checking)
+            time.sleep(0.3)
+            capture = subprocess.run(
+                ["tmux", "capture-pane", "-t", session_a, "-p", "-J"],
+                capture_output=True, text=True, check=True,
+            )
+            flat = capture.stdout.replace("\n", " ")
+            assert "--resume" in flat and uuid_a in flat, (
+                f"tmux pane should contain --resume {uuid_a}, got: {flat[:500]}"
+            )
+
+        finally:
+            core.registry = original_reg
+            for name in [session_a, session_b]:
+                subprocess.run(["tmux", "kill-session", "-t", name], capture_output=True)
+
+    @requires_tmux
+    def test_revival_falls_back_to_continue_without_uuid(self, tmp_path):
+        """Sessions without claude_session_id should fall back to --continue."""
+        import bot.core as core
+        from sessions import SessionRegistry
+
+        tmp_reg = SessionRegistry(tmp_path / "registry")
+        original_reg = core.registry
+        core.registry = tmp_reg
+
+        session_name = f"test-revival-old-{int(time.time()) % 100000}"
+
+        try:
+            # Create session without claude_session_id (pre-fix session)
+            tmp_reg.create(session_name, wolt="neowolt")
+
+            subprocess.run(["tmux", "new-session", "-d", "-s", session_name, "bash"], check=True)
+            time.sleep(0.3)
+
+            result = core.message_session(session_name, "test fallback")
+            assert result["ok"] is True
+            assert result["status"] == "revived"
+            assert "--continue" in result.get("detail", ""), (
+                f"Expected --continue fallback, got: {result.get('detail')}"
+            )
+
+        finally:
+            core.registry = original_reg
+            subprocess.run(["tmux", "kill-session", "-t", session_name], capture_output=True)
+
     def test_session_registry_atomic_writes(self, tmp_path):
         """Registry writes should use tmp+rename (no partial reads)."""
         from sessions import SessionRegistry


### PR DESCRIPTION
## Summary

- **Bug**: `message_session()` used `claude --continue` to revive dead sessions, which resumes the most recent conversation in the working directory. When multiple sessions share the same dir, this revives the wrong conversation.
- **Fix**: Generate a UUID at launch (`--session-id`), store it in the registry, and use `--resume <uuid>` on revival. Falls back to `--continue` for pre-fix sessions.
- Two regression tests: one verifying correct UUID selection, one verifying fallback behavior.

## Test plan

- [x] `test_revival_picks_correct_session` — creates sessions A and B with different UUIDs, revives A, verifies `--resume` uses A's UUID
- [x] `test_revival_falls_back_to_continue_without_uuid` — pre-fix session without UUID falls back to `--continue`
- [x] Full suite passes (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)