### PR TITLE
Update roadmap + add woltspace-as-a-project dev flow

### DIFF
--- a/DEV_FLOW.md
+++ b/DEV_FLOW.md
@@ -1,0 +1,89 @@
+# Developing Woltspace (from inside the container)
+
+This is a dev clone of woltspace, living inside a wolt's `projects/` directory.
+The mounted copy at `/workspace/woltspace/` is "production" — don't edit it directly.
+
+## The model
+
+```
+/workspace/woltspace/              ← production (mounted, serves the tunnel)
+wolt/projects/woltspace/           ← dev clone (you work here)
+wolt/projects/woltspace-branches/  ← worktrees for parallel work
+```
+
+## Quick start: single task
+
+```bash
+cd wolt/projects/woltspace
+git checkout -b feat/my-thing
+# ... make changes ...
+git add -A && git commit -m "feat: my thing"
+git push -u origin feat/my-thing
+gh pr create --title "feat: my thing" --body "..."
+```
+
+Then notify the human. They review, merge, and rebuild.
+
+## Parallel work: worktrees
+
+When multiple sessions need to work on woltspace simultaneously:
+
+```bash
+cd wolt/projects/woltspace
+
+# Session A
+git worktree add ../woltspace-branches/feat-digest -b feat/digest
+# → works in wolt/projects/woltspace-branches/feat-digest/
+
+# Session B
+git worktree add ../woltspace-branches/fix-slack -b fix/slack-ack
+# → works in wolt/projects/woltspace-branches/fix-slack/
+```
+
+Each worktree is a full copy on its own branch. No conflicts between sessions.
+
+When done:
+```bash
+cd wolt/projects/woltspace-branches/feat-digest
+git push -u origin feat/digest
+gh pr create --draft --title "feat: digest page"
+```
+
+Cleanup after merge:
+```bash
+cd wolt/projects/woltspace
+git worktree remove ../woltspace-branches/feat-digest
+git branch -d feat/digest
+```
+
+## Deploying changes
+
+Changes don't go live until they're merged to main and the mounted copy is updated:
+
+1. PR gets merged on GitHub
+2. Human runs `woltspace rebuild` (which pulls latest main)
+3. Or: `cd /workspace/woltspace && git pull` for code-only changes
+
+The tunnel always serves the mounted copy. Dev clones are for development only.
+
+## Running tests
+
+Tests run against the dev clone, not production:
+
+```bash
+cd wolt/projects/woltspace
+./test/run-tests.sh unit          # fast, no deps
+./test/run-tests.sh              # full suite (needs server + tmux)
+```
+
+## Git setup
+
+The clone uses the shared PAT from `wolts/.env` (GH_PAT_TOKEN) via credential helper.
+Commits are authored as `woltspace <woltspace@users.noreply.github.com>`.
+
+## For Haiku (bot routing)
+
+When dispatching sessions to work on woltspace:
+- Use `project=woltspace` to scope the session to this dev clone
+- For parallel tasks, the session should create a worktree and work there
+- Always push to a branch and create a PR — never commit to main directly

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,114 +1,135 @@
 # Woltspace Roadmap
 
-Organized from jerpint's airplane-mode notes (2026-03-14).
+Last updated: 2026-03-14
 
 ---
 
-## 1. Python Migration (Priority: High)
+## Recently Shipped
 
-**What:** Rewrite server.js and woltspace CLI in Python.
+### Python Server Migration (PR #16)
+FastAPI server is now the default runtime on port 3000. Node `server.js` kept for rollback. TUI service (xterm.js WebSocket) stays on Node at port 3001. Single-language goal for bot + server is ~80% there.
 
-- `server.js` → FastAPI (most API/routing logic). Keep a thin Node service only for things that need it (xterm.js WebSocket, node-pty).
-- `woltspace` CLI → Python with [click](https://click.palletsprojects.com/). Current bash is hard to read and maintain.
-- Mounts config needs a clear, documented home (currently assumed `~/wolts/.env`).
+**Still to do:** Rewrite `woltspace` CLI from bash to Python (click). Mounts config needs a documented home.
 
-**Why:** JS gets messy for jerpint to read. Python has better ecosystem for CLIs, easier to maintain. Single language for bot + server + CLI.
+### Test Framework (PR #13)
+105 tests across 6 tiers, all green (~2min full run). Covers unit → session lifecycle → server health → closed-loop → integration → agent (haiku-in-the-loop). True e2e test: haiku spawns beaver → writes HTML → verified on disk → pushed to viewport.
+
+**Still to do:** Run tests from outside the container (meta debugging). Versioning with tagged releases. CI pipeline.
+
+### Project Isolation — Phases 1 & 2 (PR #17)
+Users build in `wolt/projects/`, never touch `/workspace/woltspace/`. Guardrails at template, platform, and session-injection levels. Phase 2 added: project serving, bot tool `project=` scoping, `new-project` and `projects` skills, `migrate-to-projects` recovery skill. 38 isolation-specific tests.
+
+**Still to do (Phase 3):** Mount `/workspace/woltspace/` as read-only in container (filesystem-level enforcement). This is the north star — zero chance of platform drift.
+
+### Session Infrastructure (PRs #10, #14)
+Centralized session registry replaced tmux-based session tracking. Session revival now picks the correct conversation.
+
+### Bot & Creature Routing (PRs #8, #11)
+Creatures, notify, tool logging cleaned up. Explicit user creature choice is respected. Dog/otter split is partially in place.
+
+### Build & Init (PRs #18, #19)
+Claude CLI install cached in isolated Docker build stage (faster rebuilds). `woltspace` auto-added to PATH during init.
 
 ---
 
-## 2. Testing & CI (Priority: High)
+## Up Next
 
-**What:** Closed-loop integration tests where Claude acts as a Telegram user.
+### 1. Woltspace-as-a-Project + Parallel Development (Priority: High — in progress)
 
-- Spin up a clean container from outside
-- Have Claude (or a test harness) interface directly with the Telegram bot
-- Run health checks: create session, push to viewport, notify, kill session
-- Verify everything works end-to-end after rebuild
-- Consolidate all tests in one place (currently scattered: `test/`, `container/bot/test_*`)
-- Decouple tests from tmux where possible — tmux should only persist terminals, not manage state
+**What:** Treat woltspace development like any other project. Dev clone lives in `wolt/projects/woltspace/`, worktrees enable parallel sessions.
 
-**Why:** Debugging from within the container fails for bigger lifts. Need a meta debugging routine: rebuild clean, test from outside, inspect logs. Main should never be broken.
+- `wolt/projects/woltspace/` = dev clone (sessions work here)
+- `/workspace/woltspace/` = production (mounted, serves tunnel, read-only in practice)
+- Parallel work via `git worktree add` inside the dev clone
+- Each session pushes a branch, creates a PR — never edits main directly
+- Human reviews on phone, merges, rebuilds when ready
+- Raccoons orchestrate parallel dispatch — not Haiku
 
-**After tests are solid:** introduce versioning with tagged releases. Explore packaging (brew?).
+**Status:** Dev clone set up, flow documented in `DEV_FLOW.md`. Worktrees verified working.
+
+**Still to do:** Raccoon orchestration for multi-task requests (multiple `claude_code` calls). Supersedes the original `WORKTREE_PLAN.md` — no custom tooling needed, just projects + git.
+
+**Why:** Dogfoods the project isolation system on the hardest case. If it works for woltspace itself, it works for everything. Unlocks parallel development without custom infra.
 
 ---
 
-## 3. Telegram Hardening (Priority: High)
+### 2. Python CLI Rewrite (Priority: High)
+
+**What:** Rewrite `woltspace` CLI from bash to Python with [click](https://click.palletsprojects.com/).
+
+- Current bash script is hard to read and maintain
+- Server is already Python — CLI should match
+- Mounts config gets a clear, documented home
+
+**Why:** Completes the Python migration. One language for bot + server + CLI.
+
+---
+
+### 3. CI Pipeline (Priority: High)
+
+**What:** Automated test runs on push/PR.
+
+- Run the existing 105-test suite in CI (GitHub Actions)
+- Run from outside the container — spin up clean, test, tear down
+- Block merges on test failure
+- After CI is solid: tagged releases, semantic versioning
+
+**Why:** Tests exist but only run manually. Need to close the loop so main never breaks.
+
+---
+
+### 4. Telegram Hardening (Priority: High)
 
 **What:** Make Telegram the last line of defense — self-healing, auto-restart.
 
-- If telegram bot dies, auto-restart in container
+- If telegram bot dies, auto-restart in container (supervisor/systemd-style)
 - Telegram must stay functional even when everything else is broken
-- Dog (telegram bot) can always spawn new sessions as a fallback
+- Dog can always spawn new sessions as a fallback
 - Worst case: dog yolo-spawns a Claude to fix things
 
 **Why:** If telegram goes down while user is away from computer, they're in the dark. It's the primary control channel.
 
 ---
 
-## 4. Identity Rethink (Priority: Medium)
+### 5. Identity & Creatures (Priority: Medium)
 
-**What:** Separate creature identities for telegram bot vs den sessions.
+**What:** Finish the creature identity split.
 
-- Telegram bot → **dog** (based on Fuji ❤️). Loyal, obedient, runs tools when asked, fetches what you need. Limited abilities, no direct command execution.
-- Claude Code sessions → **otter** (current identity, becomes a Haiku session)
-- Dog is also a wolt, but with limited roles
+- Telegram bot → **dog** (based on Fuji). Loyal, constrained, runs tools, fetches what you need.
+- Claude Code sessions → **otter** (wolt identity, deeper context)
+- Dog is also a wolt, but with limited roles and shorter memory
+- Creature routing is partially shipped — needs polish and clear boundaries
 
-**Why:** Current otter-for-everything gets confused. Dog has clear, constrained role.
+**Why:** Single-identity-for-everything gets confused. Dog has a clear, constrained role.
 
 ---
 
-## 5. Skill Hierarchy (Priority: Medium)
+### 6. Skill Hierarchy (Priority: Medium)
 
 **What:** Proper skill organization — global skills all wolts share, plus wolt-specific skills.
 
 - Mirror Claude Code's user session structure
 - Global skills baked into image
 - Wolt-local skills override or extend
-- Crons should be services that fire up Claudes (headless or session) with single roles — not hardcoded scripts like digest.mjs
+- Crons should be services that fire up Claudes with single roles — not hardcoded scripts like digest.mjs
 
-**Why:** Current digest.mjs is too specific. Crons should be generic — users create their own via a meta-skill.
-
----
-
-## 6. Projects & Isolation (Priority: High — Phase 1 shipped)
-
-**What:** Isolate user work from platform code. Users build in `wolt/projects/`, never touch `/workspace/woltspace/`.
-
-**Phase 1 (shipped):**
-- `wolt/projects/` directory as the standard location for all code projects
-- CLAUDE.md guardrails at template, platform, and session-injection level that forbid editing platform code
-- Clear instructions: code goes in `wolt/projects/`, static pages in `wolt/site/`
-
-**Phase 2 (next):**
-- Projects are discoverable, registered (like sessions), can be toggled on/off
-- Bot tools get a `project=` parameter to scope sessions to a project directory
-- Session registry tracks which project each session is working on
-- Recommended stacks for easy projects (e.g. Python backend + SQLite + Vite)
-- Git-tracked per project, pushable if user provides their git
-
-**Phase 3 (future):**
-- Mount `/workspace/woltspace/` as read-only in container (filesystem-level enforcement)
-- North star: woltspace = place for tinkerers to build full-stack apps they can share from anywhere
-- Apps don't scale by design — extract and deploy elsewhere when ready
-
-**Why:** Users' Claude sessions drift into platform code, making it impossible to merge upstream woltspace updates. Isolation keeps user work portable and the platform upgradeable.
+**Why:** Current crons are too specific. Skills should be composable — users create their own via a meta-skill.
 
 ---
 
-## 7. Configuration (Priority: Medium)
+### 7. Configuration (Priority: Medium)
 
 **What:** Single source of truth for non-secret config.
 
 - `woltspace.config` (toml/yaml/json) alongside `.env`
 - Secrets stay in `.env`, everything else in config
-- Tunnel should be first-class config (not buried in env vars) — it opens a tunnel to user's computer
+- Tunnel should be first-class config (not buried in env vars)
 
 **Why:** Currently dumping too much in env vars. Need clear separation of secrets vs config.
 
 ---
 
-## 8. Memory Cleanup (Priority: Medium)
+### 8. Memory Cleanup (Priority: Medium)
 
 **What:** Active cleanup of bot (dog) memories via cron.
 
@@ -119,34 +140,33 @@ Organized from jerpint's airplane-mode notes (2026-03-14).
 
 ---
 
-## 9. Observability (Priority: Medium)
+### 9. Observability (Priority: Medium)
 
 **What:** Better tooling to debug the agent loop and message routing.
 
 - Structured logging for the full flow: user → haiku → tool call → session → notify → user
 - Currently hard to debug routing issues
+- Tie into test framework — failed flows should produce debug-friendly traces
 
 ---
 
-## 10. Fun / North Star Ideas (Priority: Low — Exploratory)
+## North Star / Exploratory
 
-### Multi-wolt collaboration
+### Read-only Platform Mount (Phase 3 of Isolation)
+Mount `/workspace/woltspace/` as read-only in container. Filesystem-level enforcement, zero trust. The ultimate guarantee that user work and platform code never collide.
+
+### Multi-wolt Collaboration
 - Wolts can enter other woltspaces as guests with limited roles/context
 - Two wolts collaborate on shared projects
-- Maybe a permission system, maybe shared woltspaces they co-own
+- Permission system or shared woltspaces
 
-### Pixel art mini game
+### Public Showcase & Pixel Art
 - Root of `/public/` shows animated pixel art of wolts doing wolt things
 - Reflects actual current state of woltspace
-- Simple Sims-like view of your wolts
 - Inspired by PostHog's OS-emulator website — windows are viewports, click a wolt to see their project
-- Part of the woltspace experience: care for how your space looks
-
-### Public showcase
 - `/public/` shows what wolts have built, how you organized your space
-- Projects, wolts, everything discoverable
 
-### Wolt blog
+### Wolt Blog
 - Give neowolt his blog back so he can post — but not all memories/context publicly
 
 ---
@@ -158,8 +178,6 @@ Organized from jerpint's airplane-mode notes (2026-03-14).
 - `sparks/` will likely be deprecated
 - Session configs should be source of truth, not tmux names + env vars
 - `wolt.json` manifest — reconsider format
-- `memory/` naming → consider "cache" or "logs" for woltspace theming
 - Update public lore, spruce up website with fun images and sprites
-- `/viewport` assumptions should be re-checked against latest rewrites
 - Templates for new wolts should be more fun out of the gate
 - Tool handlers should always return success/error flag + message explaining error


### PR DESCRIPTION
## Summary

- **ROADMAP.md** rewritten with "Recently Shipped" section (PRs #8-#19) and reordered priorities
- **DEV_FLOW.md** documents how wolts develop woltspace from inside the container using the project system
- Woltspace-as-a-project is now #1 priority — supersedes the custom WORKTREE_PLAN.md approach

## What changed

**ROADMAP.md:**
- Added "Recently Shipped" covering: Python server, 105-test framework, project isolation phases 1+2, session registry, creature routing, build caching, PATH init
- Each shipped item has "still to do" notes for loose ends
- "Up Next" reordered: (1) woltspace-as-a-project, (2) Python CLI, (3) CI, (4) Telegram hardening, (5-9) identity, skills, config, memory, observability
- "North Star" section for read-only mount, multi-wolt, pixel art, blog

**DEV_FLOW.md:**
- Full workflow: clone in projects/, branch, worktree for parallel, push PR, merge, rebuild
- Instructions for both single-task and parallel-session workflows
- Git setup, test running, Haiku routing notes

## Why this approach

Instead of building custom worktree tooling (wb CLI, activate symlink, branch param on claude_code), we treat woltspace like any other project. The project isolation system already handles scoping sessions to directories. Git worktrees are standard git — no custom infra needed.

This PR was created entirely from inside the container using the dev clone at `wolt/projects/woltspace/` — dogfooding the flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)