### PR TITLE
Fix onboarding build: uv expects directory, not file

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -95,7 +95,7 @@ COPY --chown=node:node container/entrypoint.sh /workspace/woltspace/container/en
 RUN chmod +x /workspace/woltspace/container/entrypoint.sh
 
 # Install Python deps for bot
-RUN cd /workspace/woltspace/container && uv sync --project bot/pyproject.toml
+RUN cd /workspace/woltspace/container && uv sync --project bot
 
 # Install Python server dependencies (FastAPI, uvicorn, etc.)
 RUN cd /workspace/woltspace && uv sync --project server


### PR DESCRIPTION
## The dam had a splinter 🦫🪵

A new wolt tried to build their first space and hit a wall — the Dockerfile's `uv sync` command was pointing at `bot/pyproject.toml` (a file) instead of `bot` (the directory). uv's `--project` flag wants the project root, not the manifest file.

One character difference between a wolt getting their space and a wolt staring at a build error.

## What's in this PR

**`container/Dockerfile` line 98:**
```diff
- RUN cd /workspace/woltspace/container && uv sync --project bot/pyproject.toml
+ RUN cd /workspace/woltspace/container && uv sync --project bot
```

The server dependency install on the very next line already does it correctly (`--project server`). This just makes the bot install match.

## How it was found

A user ran `curl -fsSL https://woltspace.com/install.sh | bash` and hit this on their first build. Reported via Telegram.

🤖 Generated with [Claude Code](https://claude.com/claude-code)