### PR TITLE
Make install one-liner idempotent on re-run

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -4,7 +4,17 @@ set -e
 command -v docker >/dev/null || { echo "error: docker required — https://docs.docker.com/get-docker/"; exit 1; }
 command -v git >/dev/null || { echo "error: git required"; exit 1; }
 
-git clone https://github.com/jerpint/woltspace
+if [ -d "woltspace/.git" ]; then
+  echo "  woltspace already cloned — pulling latest..."
+  git -C woltspace pull --ff-only
+elif [ -d "woltspace" ]; then
+  echo "  woltspace directory exists but isn't a git repo — removing and re-cloning..."
+  rm -rf woltspace
+  git clone https://github.com/jerpint/woltspace
+else
+  git clone https://github.com/jerpint/woltspace
+fi
+
 export PATH="$PWD/woltspace:$PATH"
 export WOLTS_DIR="${WOLTS_DIR:-$PWD}"
 


### PR DESCRIPTION
## Second gnaw's the charm 🦫🔄

When a new wolt's first build fails (like the uv bug from #23), re-running the one-liner hits a wall immediately — `git clone` refuses to clone into a directory that already exists. The user is stuck unless they know to `rm -rf woltspace` first.

Now the install script handles all three cases:
- **Fresh install** — clones as before
- **Previous attempt left a repo** — pulls latest (picks up the fix) and retries init
- **Leftover non-git directory** — cleans it up and re-clones

The `woltspace init` command itself was already mostly idempotent (checks for existing identity file, skips template copy if dir exists, etc.) — the gap was just the clone step in `install.sh`.

## What's in this PR

**`site/install.sh`:**
```diff
-git clone https://github.com/jerpint/woltspace
+if [ -d "woltspace/.git" ]; then
+  echo "  woltspace already cloned — pulling latest..."
+  git -C woltspace pull --ff-only
+elif [ -d "woltspace" ]; then
+  echo "  woltspace directory exists but isn't a git repo — removing and re-cloning..."
+  rm -rf woltspace
+  git clone https://github.com/jerpint/woltspace
+else
+  git clone https://github.com/jerpint/woltspace
+fi
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)