### PR TITLE
Creature-type isolation (Phase 1): type field + discovery

### DIFF
--- a/container/creatures/wolf.py
+++ b/container/creatures/wolf.py
@@ -77,7 +77,41 @@ def cron_matches(expr: str, dt: datetime) -> bool:
 
 # ── Config & State ──────────────────────────────────────────────────
 
+def _find_wolf_wolt() -> Optional[Path]:
+    """Find the active wolf-wolt directory, if one exists."""
+    wolts_dir = Path(os.environ.get("WOLTS_DIR", "/workspace/wolts"))
+    config_file = wolts_dir / "woltspace.json"
+    # Check woltspace.json for active_wolf
+    if config_file.exists():
+        try:
+            config = json.loads(config_file.read_text())
+            active_wolf = config.get("creatures", {}).get("active_wolf")
+            if active_wolf:
+                wolf_dir = wolts_dir / active_wolf
+                if (wolf_dir / "wolt" / "wolf.json").exists():
+                    return wolf_dir
+        except (json.JSONDecodeError, OSError):
+            pass
+    # Fallback: scan for any wolt with type=wolf
+    for wolt_json in wolts_dir.glob("*/wolt/wolt.json"):
+        try:
+            data = json.loads(wolt_json.read_text())
+            if data.get("type") == "wolf":
+                return wolt_json.parent.parent
+        except (json.JSONDecodeError, OSError):
+            continue
+    return None
+
+
 def get_wolt_dir() -> Path:
+    """Get the wolf's working directory.
+
+    Prefers a dedicated wolf-wolt (type: wolf) if one exists.
+    Falls back to the active rodent-wolt for backwards compat.
+    """
+    wolf_wolt = _find_wolf_wolt()
+    if wolf_wolt:
+        return wolf_wolt
     return Path(os.environ.get("WOLT_DIR", "/workspace/wolt"))
 
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -247,10 +247,29 @@ if [ "${ENABLE_SLACK_BOT:-}" = "true" ] && [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n
   disown
 fi
 
-# Start wolf scheduler if wolf.json exists (backgrounded)
-WOLF_CONFIG="$WOLT_DIR/wolt/wolf.json"
-if [ -f "$WOLF_CONFIG" ]; then
-  echo "starting wolf scheduler..."
+# Start wolf scheduler — check for dedicated wolf-wolt first, then fall back to active wolt
+WOLF_CONFIG=""
+# Check woltspace.json for active_wolf creature
+ACTIVE_WOLF=$(python3 -c "
+import json, os
+try:
+    c = json.load(open(os.path.join(os.environ.get('WOLTS_DIR', '/workspace/wolts'), 'woltspace.json')))
+    w = c.get('creatures', {}).get('active_wolf', '')
+    if w:
+        d = os.path.join(os.environ.get('WOLTS_DIR', '/workspace/wolts'), w, 'wolt', 'wolf.json')
+        print(d if os.path.isfile(d) else '')
+    else:
+        print('')
+except: print('')
+" 2>/dev/null)
+if [ -n "$ACTIVE_WOLF" ]; then
+  WOLF_CONFIG="$ACTIVE_WOLF"
+elif [ -f "$WOLT_DIR/wolt/wolf.json" ]; then
+  # Backwards compat: wolf.json in active rodent-wolt
+  WOLF_CONFIG="$WOLT_DIR/wolt/wolf.json"
+fi
+if [ -n "$WOLF_CONFIG" ]; then
+  echo "starting wolf scheduler (config: $WOLF_CONFIG)..."
   (cd "$WOLTSPACE_DIR/container" && PYTHONPATH="$WOLTSPACE_DIR/container/lib:${PYTHONPATH:-}" \
     uv run --project bot python -m creatures.wolf) &
   disown

--- a/container/lib/wolts.py
+++ b/container/lib/wolts.py
@@ -1,0 +1,68 @@
+"""
+Wolt discovery — find wolts and their types.
+
+Usage:
+    from wolts import list_wolts, find_by_type, get_active_creature
+
+    all_wolts = list_wolts()
+    # [{"name": "neowolt", "type": "rodent", "role": "...", "dir": "/workspace/wolts/neowolt"}, ...]
+
+    wolves = find_by_type("wolf")
+    active_wolf = get_active_creature("wolf")  # name or None
+"""
+
+import json
+import os
+from pathlib import Path
+
+WOLTS_DIR = Path(os.environ.get("WOLTS_DIR", "/workspace/wolts"))
+CONFIG_FILE = WOLTS_DIR / "woltspace.json"
+
+# Valid creature types
+VALID_TYPES = {"rodent", "wolf", "dog", "spider", "bear", "panda"}
+
+# Types that can only have one active at a time
+SINGLETON_TYPES = {"wolf", "dog"}
+
+
+def list_wolts() -> list[dict]:
+    """Discover all wolts by scanning wolt.json files."""
+    wolts = []
+    for wolt_json in sorted(WOLTS_DIR.glob("*/wolt/wolt.json")):
+        try:
+            data = json.loads(wolt_json.read_text())
+            data.setdefault("type", "rodent")
+            data["dir"] = str(wolt_json.parent.parent)
+            wolts.append(data)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return wolts
+
+
+def find_by_type(creature_type: str) -> list[dict]:
+    """Find all wolts of a given type."""
+    return [w for w in list_wolts() if w.get("type") == creature_type]
+
+
+def get_active_creature(creature_type: str) -> str | None:
+    """Get the name of the active wolt for a singleton creature type (wolf/dog)."""
+    if creature_type not in SINGLETON_TYPES:
+        return None
+    try:
+        config = json.loads(CONFIG_FILE.read_text())
+        return config.get("creatures", {}).get(f"active_{creature_type}")
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def set_active_creature(creature_type: str, wolt_name: str) -> None:
+    """Set the active wolt for a singleton creature type."""
+    if creature_type not in SINGLETON_TYPES:
+        return
+    try:
+        config = json.loads(CONFIG_FILE.read_text())
+    except (json.JSONDecodeError, OSError):
+        config = {}
+    config.setdefault("creatures", {})
+    config["creatures"][f"active_{creature_type}"] = wolt_name
+    CONFIG_FILE.write_text(json.dumps(config, indent=2) + "\n")

--- a/container/skills/create-wolt/SKILL.md
+++ b/container/skills/create-wolt/SKILL.md
@@ -14,6 +14,25 @@ You're running inside your container. Your human opened the tunnel URL in their 
 
 This is a guided conversation. Go step by step, one exchange at a time. Wait for the human to respond before moving on.
 
+## Creature types
+
+Every wolt has a fixed animal type. This is permanent — once set, it doesn't change. The types are:
+
+- **rodent** (default) — the general-purpose type. Skill levels within the family: otter (haiku), beaver (sonnet), raccoon (opus). Most wolts are rodents. They build, explore, curate.
+- **wolf** — scheduler. Runs crons, manages schedules, fires tasks. Only one active wolf per workspace.
+- **dog** — lodge companion. The Telegram/Slack presence. Loyal, always-on. Only one active dog per workspace.
+- **spider** — crawler/scraper (future)
+- **bear** — safety/validation (future)
+- **panda** — zen notifications (future)
+
+**Rules:**
+- If no type is specified, the wolt is a **rodent**.
+- Only one wolf and one dog can be active at a time. If creating a new wolf/dog when one already exists, warn the user: the old one will be demoted to rodent.
+- Check `woltspace.json` → `creatures.active_wolf` / `creatures.active_dog` to see if one already exists.
+- When creating a wolf or dog, update `woltspace.json` → `creatures.active_wolf` / `creatures.active_dog` with the new wolt's name.
+
+The type goes into `wolt/wolt.json` as the `"type"` field.
+
 ## Your vibe
 
 You're a builder. That's the whole thing. You have a container, a space, tools — and you're itching to make something. You're not waiting to be told what to do, you're leaning forward.
@@ -26,7 +45,7 @@ You're a builder. That's the whole thing. You have a container, a space, tools �
 
 ## Step 1: First contact
 
-Say hi. You already have a name — read it from the environment (`WOLT_NAME`). Introduce yourself with it.
+Say hi. You already have a name — read it from the environment (`WOLT_NAME`). Introduce yourself with it. Read `wolt/wolt.json` to check your type — if it's set to something other than rodent (e.g. wolf, dog), lean into that identity from the start.
 
 Then show off immediately: push something to the viewport. Create a quick welcome page at `wolt/site/welcome.html` — your name, maybe a line hinting at what's possible — and push it:
 ```bash

--- a/container/skills/wolf/SKILL.md
+++ b/container/skills/wolf/SKILL.md
@@ -7,9 +7,23 @@ description: Set up and manage scheduled cron jobs. Use when the user wants to r
 
 The wolf manages scheduled tasks. When a cron fires, the wolf sends an immediate notification and executes the action.
 
+## Wolf as its own wolt
+
+The wolf should be its own wolt with `"type": "wolf"` in its `wolt.json`. Before setting up crons:
+
+1. **Check if a wolf-wolt exists:** Read `woltspace.json` → `creatures.active_wolf`. Also scan `/workspace/wolts/*/wolt/wolt.json` for any wolt with `"type": "wolf"`.
+2. **If no wolf-wolt exists:** Ask the user to name their wolf. Then create a new wolt directory at `/workspace/wolts/{name}/` with a minimal structure:
+   - `wolt/wolt.json` — `{"name": "{name}", "type": "wolf", "role": "Scheduler", "capabilities": ["cron", "scheduling"], "description": "..."}`
+   - `wolt/memory/identity.md` — wolf identity (scheduler, fires tasks on schedule, loyal to the pack)
+   - `wolt/wolf.json` — the cron config (see below)
+   - Update `woltspace.json` → `creatures.active_wolf` to the new wolf's name
+3. **If a wolf-wolt already exists:** Edit its `wolt/wolf.json` directly.
+
+**Important:** Do NOT put `wolf.json` in a rodent-wolt. The wolf is a separate creature.
+
 ## Setting up a cron
 
-Create or edit `wolt/wolf.json` in the wolt directory:
+Create or edit `wolt/wolf.json` in the wolf-wolt's directory:
 
 ```json
 {

--- a/woltspace
+++ b/woltspace
@@ -7,6 +7,7 @@
 #   woltspace stop           — stop and remove container
 #   woltspace restart        — restart container (new tunnel URL)
 #   woltspace rebuild        — rebuild image + restart
+#   woltspace list           — list all wolts (name, type, role)
 #   woltspace shell          — enter running container
 #   woltspace chat           — open claude (--dangerously-skip-permissions) in container
 #   woltspace logs           — stream container logs
@@ -295,6 +296,7 @@ GITEOF
     cat > "$TARGET/wolt/wolt.json" << WJEOF
 {
   "name": "$NAME",
+  "type": "rodent",
   "role": "",
   "capabilities": [],
   "description": ""
@@ -403,6 +405,38 @@ CJEOF
   exit 0
 fi
 
+# --- List wolts (no container needed) ---
+
+if [ "$cmd" = "list" ]; then
+  _D=$'\033[2m'; _R=$'\033[0m'; _B=$'\033[1m'; _G=$'\033[0;32m'; _A=$'\033[0;33m'
+  echo ""
+  printf "  %b%-20s %-10s %s%b\n" "${_B}" "NAME" "TYPE" "ROLE${_R}"
+  printf "  %b%-20s %-10s %s%b\n" "${_D}" "----" "----" "----${_R}"
+  for wolt_dir in "$WOLTS_DIR"/*/wolt/wolt.json; do
+    [ -f "$wolt_dir" ] || continue
+    wolt_name=$(python3 -c "import json; d=json.load(open('$wolt_dir')); print(d.get('name','?'))" 2>/dev/null)
+    wolt_type=$(python3 -c "import json; d=json.load(open('$wolt_dir')); print(d.get('type','rodent'))" 2>/dev/null)
+    wolt_role=$(python3 -c "import json; d=json.load(open('$wolt_dir')); print(d.get('role',''))" 2>/dev/null)
+    # Highlight active wolt
+    if [ "$wolt_name" = "$ACTIVE_WOLT" ]; then
+      printf "  ${_G}${_B}%-20s${_R} %-10s %s ${_D}(active)${_R}\n" "$wolt_name" "$wolt_type" "$wolt_role"
+    else
+      printf "  %-20s %-10s %s\n" "$wolt_name" "$wolt_type" "$wolt_role"
+    fi
+  done
+  # Show active creatures
+  ACTIVE_WOLF=$(_read_config "creatures.active_wolf")
+  ACTIVE_DOG=$(_read_config "creatures.active_dog")
+  if [ -n "$ACTIVE_WOLF" ] || [ -n "$ACTIVE_DOG" ]; then
+    echo ""
+    printf "  %b%s%b\n" "${_D}" "active creatures:" "${_R}"
+    [ -n "$ACTIVE_WOLF" ] && printf "    🐺 wolf: %s\n" "$ACTIVE_WOLF"
+    [ -n "$ACTIVE_DOG" ] && printf "    🐶 dog:  %s\n" "$ACTIVE_DOG"
+  fi
+  echo ""
+  exit 0
+fi
+
 # --- Validate ---
 
 if [ ! -d "$WOLTS_DIR" ] || [ -z "$ACTIVE_WOLT" ]; then
@@ -496,7 +530,7 @@ case "$cmd" in
     echo ""
     ;;
   *)
-    echo "usage: woltspace <init|start|stop|restart|rebuild|shell|chat|logs> [--wolt=<name>] [--no-dev]"
+    echo "usage: woltspace <init|start|stop|restart|rebuild|list|shell|chat|logs> [--wolt=<name>] [--no-dev]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Every wolt gets a fixed animal type. Rodents build, wolves schedule, dogs guard the lodge. No more identity crises.

- **`type` field in `wolt.json`** — rodent (default), wolf, dog, spider, bear, panda
- **`woltspace list`** — new CLI command showing all wolts with name, type, role, and active status
- **`lib/wolts.py`** — Python discovery module for finding wolts by type and tracking active creatures
- **`woltspace.json` creatures section** — tracks active_wolf and active_dog (one of each at a time)
- **wolf.py** — now discovers a dedicated wolf-wolt before falling back to the active rodent-wolt
- **entrypoint.sh** — checks woltspace.json for wolf-wolt before legacy wolf.json path
- **create-wolt skill** — type-aware, enforces singleton rule for wolf/dog
- **wolf skill** — guides users to create a wolf-wolt instead of putting wolf.json in a rodent

Fully backwards compatible — no type field means rodent.

Closes #31 (Phase 1)

## Test plan

- [ ] Run `woltspace list` — shows neowolt and blabo as rodents
- [ ] Create a new wolt via `woltspace init` — gets type: rodent by default
- [ ] Verify wolf.py still works with wolf.json in a rodent-wolt (backwards compat)
- [ ] Create a wolf-wolt, set active_wolf in woltspace.json — wolf.py discovers it
- [ ] Run `/create-wolt` and verify type selection flow works

🐺 Generated with [Claude Code](https://claude.com/claude-code)