### PR TITLE
fix: session list showing undefined on home page

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -402,20 +402,20 @@
       try {
         const res = await fetch('/sessions');
         const sessions = await res.json();
-        const filtered = sessions.filter(s => s.session !== 'main');
+        const filtered = sessions.filter(s => s.name !== 'main');
         countEl.textContent = filtered.length || '0';
         if (!filtered.length) {
           listEl.innerHTML = '<div class="empty">no sessions yet — type a prompt above to start one</div>';
           return;
         }
         listEl.innerHTML = filtered.map(s => {
-          const status = s.status || (s.attached ? 'running' : 'running');
+          const status = s.status || 'running';
           const dot  = `<span class="session-dot ${status}"></span>`;
-          const time = s.started ? timeAgo(s.started) : (s.created ? timeAgo(s.created) : '');
+          const time = s.last_activity ? timeAgo(s.last_activity) : (s.created_at ? timeAgo(s.created_at) : '');
           const mainLabel = s.title
-            ? `<div class="session-title">${s.title}</div><span class="session-name">${s.session}</span>`
-            : `<div class="session-title">${s.session}</div>`;
-          return `<a class="session-item" href="/tui?session=${encodeURIComponent(s.session)}">
+            ? `<div class="session-title">${s.title}</div><span class="session-name">${s.name}</span>`
+            : `<div class="session-title">${s.name}</div>`;
+          return `<a class="session-item" href="/tui?session=${encodeURIComponent(s.name)}">
             <div class="session-left">${dot}<div>${mainLabel}</div></div>
             <span class="session-meta">${status} · ${time}</span>
           </a>`;


### PR DESCRIPTION
## The haunting

The den's session board was haunted — every name rendered as `undefined`, every timestamp blank. Sessions existed but had no identity. The home page was a ghost registry.

The frontend was speaking an older dialect the registry had long since abandoned.

## Root cause

Field names diverged at some point between the `/sessions` API and `home.html`:

| Frontend used | Registry actually returns |
|---|---|
| `s.session` | `s.name` |
| `s.started` | `s.last_activity` |
| `s.created` | `s.created_at` |

Every `s.session` reference — title, link href, filter — rendered as the string `"undefined"`.

## The fix

Six lines in `public/home.html`. Correct field names, ghosts exorcised. Sessions have names again.

## Test plan

- [ ] Home page session list shows real names instead of `undefined`
- [ ] Session links navigate to the correct session
- [ ] Timestamps show relative time (e.g. "5m ago")
- [ ] Filter correctly excludes the `main` session

🦫 Generated with [Claude Code](https://claude.com/claude-code)