### PR TITLE
Fix update checker branch mismatch in dev mode

### DIFF
--- a/container/bot/core.py
+++ b/container/bot/core.py
@@ -760,10 +760,12 @@ def _tool_check_update(args: dict, routing: dict | None) -> str:
     """Check if a woltspace update is available."""
     import subprocess
     version_file = WOLT_DIR / ".state" / "woltspace-version"
+    branch_file = WOLT_DIR / ".state" / "woltspace-branch"
+    # Check against the branch we built from (default: main)
+    build_branch = branch_file.read_text().strip() if branch_file.exists() else "main"
     try:
-        # Use git ls-remote to check remote main HEAD (no full repo needed)
         result = subprocess.run(
-            ["git", "ls-remote", "https://github.com/jerpint/woltspace.git", "refs/heads/main"],
+            ["git", "ls-remote", "https://github.com/jerpint/woltspace.git", f"refs/heads/{build_branch}"],
             capture_output=True, text=True, timeout=10,
         )
         remote_head = result.stdout.strip().split("\t")[0] if result.stdout.strip() else ""

--- a/container/cron/check-update.sh
+++ b/container/cron/check-update.sh
@@ -4,7 +4,8 @@
 #
 # Designed to run as a wolf cron job (e.g., daily).
 # Stores last-known version in .state/woltspace-version.
-# If remote main has moved ahead, notifies the user.
+# If the remote branch has moved ahead, notifies the user.
+# Reads .state/woltspace-branch to know which branch to check (default: main).
 
 set -e
 
@@ -12,9 +13,16 @@ WOLTSPACE_REPO="https://github.com/jerpint/woltspace.git"
 WOLT_DIR="${WOLT_DIR:-/workspace/wolts/${WOLT_NAME:-wolt}}"
 STATE_DIR="$WOLT_DIR/.state"
 VERSION_FILE="$STATE_DIR/woltspace-version"
+BRANCH_FILE="$STATE_DIR/woltspace-branch"
 
-# Get remote main HEAD (no clone needed)
-REMOTE_HEAD=$(git ls-remote "$WOLTSPACE_REPO" refs/heads/main 2>/dev/null | cut -f1)
+# Read which branch we built from (default: main)
+BUILD_BRANCH="main"
+if [ -f "$BRANCH_FILE" ]; then
+  BUILD_BRANCH=$(cat "$BRANCH_FILE")
+fi
+
+# Get remote HEAD for the branch we're tracking (no clone needed)
+REMOTE_HEAD=$(git ls-remote "$WOLTSPACE_REPO" "refs/heads/$BUILD_BRANCH" 2>/dev/null | cut -f1)
 
 if [ -z "$REMOTE_HEAD" ]; then
   echo "[update-check] could not reach remote"

--- a/test/test_wolf.py
+++ b/test/test_wolf.py
@@ -492,6 +492,41 @@ class TestCheckUpdateTool:
             result = json.loads(_tool_check_update({}, None))
         assert "error" in result
 
+    def test_staging_branch_compared_correctly(self, tmp_path):
+        """When built from staging, check_update should compare against staging, not main."""
+        from bot.core import _tool_check_update
+        state_dir = tmp_path / ".state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "woltspace-version").write_text("staging_commit_abc123")
+        (state_dir / "woltspace-branch").write_text("staging")
+
+        mock_result = MagicMock()
+        mock_result.stdout = "staging_commit_abc123\trefs/heads/staging\n"
+
+        with patch("bot.core.WOLT_DIR", tmp_path), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = json.loads(_tool_check_update({}, None))
+        assert result["up_to_date"] is True
+        # Verify it checked staging, not main
+        mock_run.assert_called_once()
+        assert "refs/heads/staging" in mock_run.call_args[0][0]
+
+    def test_defaults_to_main_without_branch_file(self, tmp_path):
+        """Without a branch file, should default to checking main."""
+        from bot.core import _tool_check_update
+        state_dir = tmp_path / ".state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "woltspace-version").write_text("abc1234567890")
+
+        mock_result = MagicMock()
+        mock_result.stdout = "abc1234567890\trefs/heads/main\n"
+
+        with patch("bot.core.WOLT_DIR", tmp_path), \
+             patch("subprocess.run", return_value=mock_result) as mock_run:
+            result = json.loads(_tool_check_update({}, None))
+        assert result["up_to_date"] is True
+        assert "refs/heads/main" in mock_run.call_args[0][0]
+
 
 # ---------------------------------------------------------------------------
 # Notify footer (from server/notify.py)

--- a/woltspace
+++ b/woltspace
@@ -546,11 +546,12 @@ case "$cmd" in
     rm -f "$ACTIVE_WOLT_DIR/.state/tunnel-url"
     docker build -t woltspace -f "$WOLTSPACE_DIR/container/Dockerfile" "$WOLTSPACE_DIR"
 
-    # Stamp the version so the update-check cron knows what we're running
+    # Stamp the version + branch so the update-check cron compares against the right remote
     BUILD_COMMIT=$(cd "$WOLTSPACE_DIR" && git rev-parse HEAD 2>/dev/null)
     if [ -n "$BUILD_COMMIT" ]; then
       mkdir -p "$ACTIVE_WOLT_DIR/.state"
       echo "$BUILD_COMMIT" > "$ACTIVE_WOLT_DIR/.state/woltspace-version"
+      echo "$BUILD_BRANCH" > "$ACTIVE_WOLT_DIR/.state/woltspace-branch"
     fi
 
     _ensure_container "$CONTAINER_NAME"


### PR DESCRIPTION
## Summary

The update checker (both `check-update.sh` cron and `check_update` dog tool) always compared the stored version against `refs/heads/main`. But `rebuild --dev` stamps the **staging** commit — so in dev mode, it always reports a false "update available."

**Fix:** `rebuild` now writes `.state/woltspace-branch` alongside the version hash. Both checkers read it and compare against the correct remote branch. Defaults to `main` when no branch file exists (backwards compatible).

- `woltspace` CLI: stamps branch on rebuild
- `check-update.sh`: reads branch file, checks correct remote
- `core.py` `check_update`: same
- 2 new tests: staging branch comparison + default-to-main fallback

## Test plan
- [x] All 51 wolf tests pass (including 2 new branch-aware tests)
- [ ] `rebuild --dev` → dog `check_update` → should say up to date
- [ ] `rebuild` (main) → same behavior as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)