### PR TITLE
Merge staging: two-branch model, update checker, wolf seeding

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -140,6 +140,7 @@ split.html polls /current/meta every 2s
 | `list_wolts` | Multi-wolt: show available wolts |
 | `list_projects` | List projects in current wolt (names, paths, metadata) |
 | `switch_wolt` | Change active wolt identity |
+| `check_update` | Check if woltspace update is available (git ls-remote, no LLM) |
 | `generate_image` | AI image gen (OpenAI) |
 
 ---
@@ -165,16 +166,19 @@ CREATED → RUNNING → COMPLETED / FAILED
 1. Install dev deps (if volume-mounted)
 2. Resolve WOLT_DIR from WOLTS_DIR/WOLT_NAME
 3. Copy skills: platform defaults + wolt overrides → ~/.claude/skills/
-4. SSH/git config (deploy key if present)
-5. Write OAuth credentials
-6. Install Claude Code hooks (notify + session-done)
-7. Start tmux main session → auto-launch Claude
-8. Start node --watch server.js (port 3000)
-9. Start cloudflared tunnel → write URL to .state/tunnel-url
-10. Start Telegram bot (optional, watchfiles reload)
-11. Start Slack bot (optional, watchfiles reload)
-12. Symlink node_modules for ESM resolution
-13. wait -n (exit if ANY critical process dies)
+4. Seed default wolf.json if active wolt doesn't have one (update checker)
+5. SSH/git config (deploy key if present)
+6. Write OAuth credentials
+7. Install Claude Code hooks (notify + session-done)
+8. Start tmux main session → auto-launch Claude
+9. Start TUI pty service (port 3001)
+10. Start FastAPI server (port 3000)
+11. Start cloudflared tunnel → write URL to .state/tunnel-url
+12. Start Telegram bot (optional, watchfiles reload)
+13. Start Slack bot (optional, watchfiles reload)
+14. Start wolf scheduler (if wolf.json exists)
+15. Symlink node_modules for ESM resolution
+16. wait -n (exit if ANY critical process dies)
 ```
 
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,9 +83,30 @@ woltspace
 The host-side CLI. Commands:
 - `woltspace init` — create a new wolt from template
 - `woltspace start` — start the container
-- `woltspace stop/restart/rebuild/shell/logs`
+- `woltspace stop/restart/shell/logs`
+- `woltspace rebuild` — rebuild image from `main` branch (stable, default)
+- `woltspace rebuild --dev` — rebuild image from `staging` branch (latest, may be rough)
+- `woltspace update` — check if a new version is available (compares local vs remote `main`)
 
 Reads `.env` for secrets, mounts all wolts into the container.
+
+### Branch Model
+
+Two branches:
+- **`main`** — stable. What containers run by default. What users install. Only gets merges via PR from staging.
+- **`staging`** — the workshop. All development merges here first via PR. Hot-reloaded only when explicitly pulled with `--dev`.
+
+Development workflow: `wt create feature-name` → work → PR to staging → merge → when staging is solid, PR staging → main.
+
+### Updates
+
+Updates are opt-in, never automatic:
+1. A **wolf cron** (`check-update.sh`) runs daily, compares local version against remote `main` using `git ls-remote`. If behind, sends a 🐺 notification: *"update available — ask a beaver or raccoon to update."*
+2. The **dog** has a `check_update` tool — when asked "is there an update?", it checks inline and reports.
+3. User asks a **rodent** (beaver/raccoon) to handle the update. The rodent evaluates the diff, explains impact, and only proceeds with user consent.
+4. `woltspace update` on the host shows the same info (commits behind + changelog).
+
+Version tracking: `.state/woltspace-version` stores the commit hash after each `rebuild`.
 
 ### `server.js` (Node.js, ~1400 lines)
 Single-file HTTP + WebSocket server running on port 3000 inside the container.
@@ -100,7 +121,7 @@ Single-file HTTP + WebSocket server running on port 3000 inside the container.
 ### `container/bot/core.py` (Python)
 The bot brain. Loaded by Telegram/Slack adapters. Uses **litellm** for LLM routing.
 - Builds system prompt from wolt memory files
-- Defines tools: `claude_code`, `new_session`, `get_tunnel_url`, `check_session`, `get_recent_sessions`, `list_sessions`, `find_session`, `kill_session`, `send_message`, `read_memory`, `list_wolts`, `list_projects`, `generate_image`, `switch_wolt`, `wolf_schedules`, `fire_wolf`
+- Defines tools: `claude_code`, `new_session`, `get_tunnel_url`, `check_session`, `get_recent_sessions`, `list_sessions`, `find_session`, `kill_session`, `send_message`, `read_memory`, `list_wolts`, `list_projects`, `generate_image`, `switch_wolt`, `check_update`, `wolf_schedules`, `fire_wolf`
 - When `claude_code` is called: spawns a tmux session running `run-session.sh` → Claude Code CLI
 - Session metadata (status, routing, creature, viewport) stored in the **session registry** — see `container/lib/sessions.py`
 
@@ -112,17 +133,22 @@ Image based on `node:22-slim`. Installs: cloudflared, uv, Claude Code CLI, tmux.
 The Dockerfile uses a multi-stage build: Claude Code CLI is installed in an isolated `claude` stage, cached independently of app source changes. To update Claude without rebuilding everything: `docker build --no-cache-filter=claude ...`
 Entrypoint:
 1. Merges platform skills + wolt overrides into `~/.claude/skills/`
-2. Writes OAuth credentials and trust config
-3. Starts tmux `main` session with Claude Code auto-running
-4. Starts Node server with `--watch`
-5. Starts cloudflared tunnel (URL written to `.state/tunnel-url`)
-6. Optionally starts Telegram/Slack bot
+2. Seeds default `wolf.json` if the active wolt doesn't have one (ensures update checker runs for all users)
+3. Writes OAuth credentials and trust config
+4. Starts tmux `main` session with Claude Code auto-running
+5. Starts Node server with `--watch`
+6. Starts cloudflared tunnel (URL written to `.state/tunnel-url`)
+7. Optionally starts Telegram/Slack bot
+8. Starts wolf scheduler if `wolf.json` exists (dedicated wolf-wolt or active rodent-wolt fallback)
 
 ### `container/skills/`
 Discovery files Claude Code reads from `~/.claude/skills/`. Platform defaults baked into image; wolts can override. Current skills: `apps`, `projects`, `new-project`, `migrate-to-projects`, `create-wolt`, `digest`, `music`, `viewport`, `telegram`, `notify`, `session-summary`, `organize-context`, `wolf`, `worktui`, `update-2026-03-13`.
 
 ### `container/cron/digest.mjs`
 Daily digest pipeline (3 phases): fetch (HN, HuggingFace, Lobsters) → select via `claude -p` → render HTML. Writes to `wolt/sparks/`. Optional Spotify playlist curation.
+
+### `container/cron/check-update.sh`
+No-LLM update checker. Compares stored version (`.state/woltspace-version`) against remote `main` HEAD via `git ls-remote`. Only notifies (as 🐺) when an update is found — completely silent otherwise. Designed to run as a daily wolf cron.
 
 ### `container/creatures/wolf.py` (Wolf Scheduler 🐺)
 Background cron service. Reads `wolt/wolf.json` for scheduled tasks, fires them on time, sends 🐺 notifications. Actions: `script` (shell command), `session` (Claude Code session), `skill` (invoke a skill). Tracks last-run per cron entry in `.state/wolf/`. Auto-starts when `wolf.json` exists. See `/wolf` skill for full config format.
@@ -284,7 +310,7 @@ bash test/run-tests.sh -k "pattern" # pass any pytest args
 - `test_telegram_loop.py` — Telegram adapter: message parsing, formatting, allowlist, notify round-trip, live API
 - `test_closed_loop.py` — full seam tests: Telegram API → notify pipeline → session creation → den reply → round-trip
 - `test_agent_loop.py` — haiku decision tests (mocked tools), conversation simulator, live session spawn, true e2e (haiku → beaver → file on disk → viewport)
-- `test_wolf.py` — wolf scheduler: cron parser, schedule loading, state tracking, dispatch routing, fire-by-name, wolf_schedules/fire_wolf tools
+- `test_wolf.py` — wolf scheduler: cron parser, schedule loading, state tracking, dispatch routing, fire-by-name, wolf_schedules/fire_wolf/check_update tools, notify footer logic
 - `test_wolts.py` — wolt discovery, creature-type system, creature-wolt creation, singleton demotion, dog identity loading
 
 **Environment:**
@@ -301,23 +327,25 @@ bash test/run-tests.sh -k "pattern" # pass any pytest args
 
 ### ⚠️ HARD RULE: Never edit on main
 
-**All changes happen on branches, never on main directly.** Use a worktree for every change:
+**All changes happen on branches, never on main or staging directly.** Use a worktree for every change:
 
 ```bash
 wt create nw/my-feature      # creates isolated worktree
 # ... make changes, commit, push ...
-# open PR, get it reviewed, merge
+# open PR targeting staging, get it reviewed, merge
 wt delete nw/my-feature --branch   # clean up
 ```
 
-After merge, pull main to get the changes:
+PRs target **staging** first. When staging is solid, a PR from staging → main ships it to users.
+
+After merge to staging, pull to get the changes:
 ```bash
-cd /workspace/woltspace && git checkout main && git pull
+cd /workspace/woltspace && git checkout staging && git pull
 ```
 
-For quick local testing of a branch before merging, you can temporarily checkout the branch on main — but **never commit to main directly**.
+To test staging locally: `woltspace rebuild --dev` (builds from staging instead of main).
 
-**Why:** The container runs main. A bad edit on main crashes the server, tunnel, and bot for everyone. Branches + PRs give us a review gate.
+**Why:** The container runs main by default. A bad edit on main crashes the server, tunnel, and bot for everyone. Staging is the buffer — test there, ship to main when ready.
 
 ### Dev mode
 

--- a/DEV_FLOW.md
+++ b/DEV_FLOW.md
@@ -56,13 +56,23 @@ git worktree remove ../woltspace-branches/feat-digest
 git branch -d feat/digest
 ```
 
+## Branch model
+
+Two branches:
+- **`main`** — stable. What containers run by default. What users install.
+- **`staging`** — the workshop. All development merges here first via PR.
+
+PRs target **staging**. When staging is solid, a PR from staging → main ships to users.
+
 ## Deploying changes
 
-Changes don't go live until they're merged to main and the mounted copy is updated:
+Changes go through staging first, then to main:
 
-1. PR gets merged on GitHub
-2. Human runs `woltspace rebuild` (which pulls latest main)
-3. Or: `cd /workspace/woltspace && git pull` for code-only changes
+1. PR gets merged to **staging** on GitHub
+2. Test with `woltspace rebuild --dev` (builds from staging)
+3. When ready to ship: PR from staging → main
+4. Human runs `woltspace rebuild` (builds from main — the default)
+5. Or: `cd /workspace/woltspace && git pull` for code-only changes in dev mode
 
 The tunnel always serves the mounted copy. Dev clones are for development only.
 

--- a/HUMANS.md
+++ b/HUMANS.md
@@ -71,9 +71,26 @@ The container runs a Node server + cloudflared tunnel. The wolt has Claude Code 
 | `woltspace start` | Start container, open in browser |
 | `woltspace stop` | Stop and remove container |
 | `woltspace restart` | Restart container (new tunnel URL) |
-| `woltspace rebuild` | Rebuild Docker image + restart (Claude CLI cached) |
+| `woltspace rebuild` | Rebuild image from `main` (stable) + restart |
+| `woltspace rebuild --dev` | Rebuild image from `staging` (latest, may be rough) |
+| `woltspace update` | Check if a new version is available |
 | `woltspace shell` | Shell into running container |
 | `woltspace logs` | Stream container logs |
+
+## Updates
+
+Updates are opt-in — your wolt checks for them daily and lets you know.
+
+**How it works:**
+- A wolf cron runs once a day, checks if `main` has moved ahead of your local version
+- If an update is available, you get a 🐺 notification: *"update available — ask a beaver or raccoon"*
+- You can also ask the dog directly: *"is there an update?"*
+- When ready, ask any rodent session to update — it'll evaluate the changes, explain impact, and wait for your go-ahead
+- Or from the host: `woltspace update` to check manually
+
+**Two branches:**
+- `woltspace rebuild` builds from `main` — stable, tested, what you should run
+- `woltspace rebuild --dev` builds from `staging` — latest development, may have rough edges
 
 ## How it works
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,15 +41,30 @@ Claude CLI install cached in isolated Docker build stage (faster rebuilds). `wol
 - `wolt/projects/woltspace/` = dev clone (sessions work here)
 - `/workspace/woltspace/` = production (mounted, serves tunnel, read-only in practice)
 - Parallel work via `git worktree add` inside the dev clone
-- Each session pushes a branch, creates a PR — never edits main directly
-- Human reviews on phone, merges, rebuilds when ready
+- Each session pushes a branch, creates a PR targeting **staging** — never edits main directly
+- Human reviews on phone, merges to staging, then staging → main when ready to ship
 - Raccoons orchestrate parallel dispatch — not Haiku
 
-**Status:** Dev clone set up, flow documented in `DEV_FLOW.md`. Worktrees verified working.
+**Status:** Dev clone set up, flow documented in `DEV_FLOW.md`. Worktrees verified working. **Staging branch live** — `woltspace rebuild --dev` builds from staging, `woltspace rebuild` builds from main (stable default).
 
-**Still to do:** Raccoon orchestration for multi-task requests (multiple `claude_code` calls). Supersedes the original `WORKTREE_PLAN.md` — no custom tooling needed, just projects + git.
+**Still to do:** Raccoon orchestration for multi-task requests (multiple `claude_code` calls). Supersedes the original `WORKTREE_PLAN.md` — no custom tooling needed, just projects + git. GitHub branch protection on staging (manual setup). Raccoon migration evaluator (reads diff, explains impact to user before updating).
 
 **Why:** Dogfoods the project isolation system on the hardest case. If it works for woltspace itself, it works for everything. Unlocks parallel development without custom infra.
+
+### 1b. Update System (Priority: High — shipped)
+
+**What:** Opt-in update notifications + self-serve update flow.
+
+- **Wolf cron** (`check-update.sh`) — runs daily, no LLM. Uses `git ls-remote` to check remote `main`. If behind, sends 🐺 notification: *"update available — ask a beaver or raccoon."*
+- **Dog tool** (`check_update`) — inline check when asked "is there an update?" Uses same `git ls-remote` approach.
+- **CLI** (`woltspace update`) — host-side check, shows commits behind + changelog.
+- **Rodent handles the update** — evaluates diff, explains scope (clean merge vs breaking changes), user decides.
+- Version tracked in `.state/woltspace-version`, stamped on every `rebuild`.
+- Default `wolf.json` seeded for all wolts (new + existing) via entrypoint — ensures update checker runs from the start.
+
+**Status:** Shipped in PR #38. Wolf cron, dog tool, CLI command, entrypoint seeding, tests all in place.
+
+**Design:** No auto-updates, no background magic. Wolf is the lookout, rodent has hands on keyboard, user has final say.
 
 ---
 
@@ -169,7 +184,7 @@ The colony is expanding. Each creature has a single, clear role. Not all are bui
 
 | Creature | Emoji | Role | Entry Point |
 |----------|-------|------|-------------|
-| **wolf** | 🐺 | Cron & scheduler — runs the pack's routines. Fires tasks on schedule, tracks cadence. | `container/creatures/wolf.py` |
+| **wolf** | 🐺 | Cron & scheduler — runs the pack's routines. Fires tasks on schedule, tracks cadence. Ships with a default daily update checker. | `container/creatures/wolf.py` |
 | **spider** | 🕷️ | Headless browser — crawls, scrapes, watches the web. Playwright-backed, quiet and fast. | `container/creatures/spider.py` |
 | **bear** | 🐻 | Safety & validation — guards the den. Reviews outputs, flags risks, enforces boundaries. | `container/creatures/bear.py` |
 | **panda** | 🐼 | Daily reminders & zen notifications — gentle, unhurried. Surfaces what matters, when it matters. | `container/creatures/panda.py` |

--- a/container/bot/core.py
+++ b/container/bot/core.py
@@ -193,6 +193,7 @@ You have tools. Use them. Never describe what you would do — always invoke the
 CRITICAL: If a task requires claude_code, call claude_code. Don't narrate what you'd do instead.
 
 - **claude_code** — spin up a Claude Code session for real work (pick raccoon, beaver, otter, or wolf as needed)
+- **check_update** — check if a woltspace update is available. If yes, suggest the user ask a beaver or raccoon to update
 - **wolf_schedules** — check what crons are configured and when they last ran
 - **fire_wolf** — trigger a specific cron immediately by name (check wolf_schedules first for names)
 - **send_message** — send a message to a running session
@@ -755,6 +756,41 @@ def _tool_switch_wolt(args: dict, routing: dict | None) -> str:
     return json.dumps({"switched": bool(switched), "name": args["name"]})
 
 
+def _tool_check_update(args: dict, routing: dict | None) -> str:
+    """Check if a woltspace update is available."""
+    import subprocess
+    version_file = WOLT_DIR / ".state" / "woltspace-version"
+    try:
+        # Use git ls-remote to check remote main HEAD (no full repo needed)
+        result = subprocess.run(
+            ["git", "ls-remote", "https://github.com/jerpint/woltspace.git", "refs/heads/main"],
+            capture_output=True, text=True, timeout=10,
+        )
+        remote_head = result.stdout.strip().split("\t")[0] if result.stdout.strip() else ""
+        if not remote_head:
+            return json.dumps({"error": "could not reach remote"})
+
+        local_version = version_file.read_text().strip() if version_file.exists() else ""
+
+        if not local_version:
+            # First check — store version for future comparisons
+            version_file.parent.mkdir(parents=True, exist_ok=True)
+            version_file.write_text(remote_head)
+            return json.dumps({"up_to_date": True, "version": remote_head[:7], "note": "version tracking initialized"})
+
+        if local_version == remote_head:
+            return json.dumps({"up_to_date": True, "version": remote_head[:7]})
+
+        return json.dumps({
+            "up_to_date": False,
+            "local": local_version[:7],
+            "remote": remote_head[:7],
+            "message": "an update is available — suggest the user ask a beaver or raccoon to handle it",
+        })
+    except Exception as e:
+        return json.dumps({"error": str(e)})
+
+
 def _tool_wolf_schedules(args: dict, routing: dict | None) -> str:
     """List all wolf cron schedules for the active wolt."""
     wolf_config = WOLT_DIR / "wolt" / "wolf.json"
@@ -810,6 +846,7 @@ TOOL_HANDLERS: dict[str, callable] = {
     "new_session": _tool_new_session,
     "wolf_schedules": _tool_wolf_schedules,
     "fire_wolf": _tool_fire_wolf,
+    "check_update": _tool_check_update,
 }
 
 
@@ -1068,6 +1105,17 @@ TOOLS = [
                     },
                 },
                 "required": ["name"],
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": "check_update",
+            "description": "Check if a woltspace platform update is available. Use when someone asks 'is there an update?', 'any updates?', 'check for updates', or 'is woltspace up to date?'. Returns whether the platform is current or behind, and suggests routing to a rodent if an update is available.",
+            "parameters": {
+                "type": "object",
+                "properties": {},
             },
         },
     },

--- a/container/cron/check-update.sh
+++ b/container/cron/check-update.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Check if a woltspace update is available
+# No LLM — just git ls-remote + compare + notify
+#
+# Designed to run as a wolf cron job (e.g., daily).
+# Stores last-known version in .state/woltspace-version.
+# If remote main has moved ahead, notifies the user.
+
+set -e
+
+WOLTSPACE_REPO="https://github.com/jerpint/woltspace.git"
+WOLT_DIR="${WOLT_DIR:-/workspace/wolts/${WOLT_NAME:-wolt}}"
+STATE_DIR="$WOLT_DIR/.state"
+VERSION_FILE="$STATE_DIR/woltspace-version"
+
+# Get remote main HEAD (no clone needed)
+REMOTE_HEAD=$(git ls-remote "$WOLTSPACE_REPO" refs/heads/main 2>/dev/null | cut -f1)
+
+if [ -z "$REMOTE_HEAD" ]; then
+  echo "[update-check] could not reach remote"
+  exit 0
+fi
+
+# Read stored version
+LOCAL_VERSION=""
+if [ -f "$VERSION_FILE" ]; then
+  LOCAL_VERSION=$(cat "$VERSION_FILE")
+fi
+
+# First run — store current version, don't notify
+if [ -z "$LOCAL_VERSION" ]; then
+  mkdir -p "$STATE_DIR"
+  echo "$REMOTE_HEAD" > "$VERSION_FILE"
+  echo "[update-check] initialized version tracking ($(echo "$REMOTE_HEAD" | cut -c1-7))"
+  exit 0
+fi
+
+# Compare
+if [ "$LOCAL_VERSION" = "$REMOTE_HEAD" ]; then
+  echo "[update-check] up to date ($(echo "$REMOTE_HEAD" | cut -c1-7))"
+  exit 0
+fi
+
+# Update available — notify as wolf (bypass notify script which needs a session)
+LOCAL_SHORT=$(echo "$LOCAL_VERSION" | cut -c1-7)
+REMOTE_SHORT=$(echo "$REMOTE_HEAD" | cut -c1-7)
+
+WOLT_NAME="${WOLT_NAME:-wolt}"
+MESSAGE="a woltspace update is available ($LOCAL_SHORT -> $REMOTE_SHORT). to update, ask a beaver or raccoon: \"can you update woltspace?\""
+FULL_MESSAGE=$(python3 -c "import json; print(json.dumps({'session': '', 'message': json.loads(json.dumps('🐺 $WOLT_NAME: $MESSAGE'))}))" 2>/dev/null)
+
+curl -s -X POST http://localhost:3000/notify \
+  -H "Content-Type: application/json" \
+  -d "$FULL_MESSAGE" > /dev/null 2>&1 || \
+  echo "[update-check] update available ($LOCAL_SHORT -> $REMOTE_SHORT) — notify failed"
+
+echo "[update-check] notified: update available ($LOCAL_SHORT -> $REMOTE_SHORT)"

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -250,6 +250,13 @@ if [ "${ENABLE_SLACK_BOT:-}" = "true" ] && [ -n "${SLACK_BOT_TOKEN:-}" ] && [ -n
   disown
 fi
 
+# Seed default wolf.json if active wolt doesn't have one
+# Ensures all users get the update checker without requiring manual setup
+if [ ! -f "$WOLT_DIR/wolt/wolf.json" ] && [ -f "$WOLTSPACE_DIR/template/wolt/wolf.json" ]; then
+  cp "$WOLTSPACE_DIR/template/wolt/wolf.json" "$WOLT_DIR/wolt/wolf.json"
+  echo "seeded default wolf.json (update checker) for $WOLT_NAME"
+fi
+
 # Start wolf scheduler — check for dedicated wolf-wolt first, then fall back to active wolt
 WOLF_CONFIG=""
 # Check woltspace.json for active_wolf creature

--- a/container/skills/wolf/HUMANS.md
+++ b/container/skills/wolf/HUMANS.md
@@ -86,12 +86,19 @@ python -m creatures.wolf                # run as background service
 
 ## Dog integration
 
-The Telegram/Slack bot (dog 🐶) has two wolf tools:
+The Telegram/Slack bot (dog 🐶) has three wolf-related tools:
 
 - **`wolf_schedules`** — "what's scheduled?" → lists all crons + last run times
 - **`fire_wolf`** — "run the digest now" → triggers a cron by name
+- **`check_update`** — "is there an update?" → checks if woltspace has a newer version available (git ls-remote, no LLM needed)
 
 Dog can also spawn a **wolf session** (`creature="wolf"`) to help users set up or edit their `wolf.json` interactively.
+
+## Default update checker
+
+Every wolt ships with a built-in `update-check` cron that runs daily at 10am. It compares your local woltspace version against remote `main` — only notifies if an update is found (silent otherwise). No LLM, no sessions, just `git ls-remote`.
+
+If notified, ask a beaver or raccoon to handle the update — they'll evaluate the diff and explain what changed before proceeding.
 
 ## Key files
 
@@ -105,4 +112,4 @@ wolt/wolf.json                        ← per-wolt schedule config
 
 ## Auto-start
 
-Wolf starts automatically when `wolt/wolf.json` exists — the entrypoint checks for the file and launches `wolf.py` as a background process. No manual setup needed. Edit the JSON, wolf picks it up within 30 seconds.
+Wolf starts automatically when `wolt/wolf.json` exists — the entrypoint checks for the file and launches `wolf.py` as a background process. If the active wolt has no `wolf.json`, the entrypoint seeds one from the template (containing the update checker). No manual setup needed. Edit the JSON, wolf picks it up within 30 seconds.

--- a/container/skills/wolf/SKILL.md
+++ b/container/skills/wolf/SKILL.md
@@ -127,11 +127,33 @@ python -m creatures.wolf --fire NAME    # Fire a specific cron by name (ignores 
 python -m creatures.wolf                # Run as background service (auto-started by entrypoint)
 ```
 
+## Default crons
+
+Every wolt ships with a default `wolf.json` containing the **update checker** — a daily cron that checks if a woltspace update is available:
+
+```json
+{
+  "crons": [
+    {
+      "name": "update-check",
+      "schedule": "0 10 * * *",
+      "action": "script",
+      "command": "bash /workspace/woltspace/container/cron/check-update.sh",
+      "timezone": "America/Montreal"
+    }
+  ]
+}
+```
+
+The update checker uses `git ls-remote` (no LLM, no clone) to compare the stored version against remote `main`. It only sends a 🐺 notification when an update is actually found — completely silent otherwise. Version is tracked in `.state/woltspace-version`.
+
+When adding new crons, add them to the existing `crons` array alongside the update checker.
+
 ## How it works
 
 - Wolf reads `wolt/wolf.json` every 30 seconds
 - When a cron matches the current time, wolf fires it (idempotent — won't double-fire within the same minute)
-- Notifications go via 🐺 through the existing notify pipeline
+- Notifications go via 🐺 through the existing notify pipeline (sessionless notifications skip the reply footer)
 - Last-run timestamps stored in `.state/wolf/{name}.last`
-- Wolf starts automatically when `wolt/wolf.json` exists (entrypoint checks)
+- Wolf starts automatically when `wolt/wolf.json` exists (entrypoint seeds a default if missing)
 - To add a new cron, just edit wolf.json — wolf picks it up on next check

--- a/server/notify.py
+++ b/server/notify.py
@@ -93,8 +93,11 @@ async def send_notification(session: str, message: str) -> dict:
             tunnel_url = tunnel_file.read_text().strip()
         except Exception:
             pass
-        session_url = f"{tunnel_url}/tui?session={session}" if tunnel_url else f"session={session}"
-        footer = f"\n\n---{DEN_REPLY_FOOTER}\n{session_url}"
+        # Only append session footer if there's an actual session (skip for wolf cron, system notifications)
+        footer = ""
+        if session:
+            session_url = f"{tunnel_url}/tui?session={session}" if tunnel_url else f"session={session}"
+            footer = f"\n\n---{DEN_REPLY_FOOTER}\n{session_url}"
         await telegram_send(telegram_token, telegram_chat_id, message + footer)
         append_chat_history("telegram", telegram_chat_id, message)
         return {"adapter": "telegram", "chat_id": telegram_chat_id}

--- a/template/wolt/wolf.json
+++ b/template/wolt/wolf.json
@@ -1,0 +1,11 @@
+{
+  "crons": [
+    {
+      "name": "update-check",
+      "schedule": "0 10 * * *",
+      "action": "script",
+      "command": "bash /workspace/woltspace/container/cron/check-update.sh",
+      "timezone": "America/Montreal"
+    }
+  ]
+}

--- a/test/test_wolf.py
+++ b/test/test_wolf.py
@@ -427,3 +427,93 @@ class TestFireWolfTool:
         from bot.core import _tool_fire_wolf
         result = json.loads(_tool_fire_wolf({"name": ""}, None))
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# check_update tool (from core.py)
+# ---------------------------------------------------------------------------
+
+class TestCheckUpdateTool:
+    """Unit: the check_update tool exposed to the dog."""
+
+    def test_up_to_date(self, tmp_path):
+        from bot.core import _tool_check_update
+        version_file = tmp_path / ".state" / "woltspace-version"
+        version_file.parent.mkdir(parents=True)
+        version_file.write_text("abc1234567890")
+
+        mock_result = MagicMock()
+        mock_result.stdout = "abc1234567890\trefs/heads/main\n"
+
+        with patch("bot.core.WOLT_DIR", tmp_path), \
+             patch("subprocess.run", return_value=mock_result):
+            result = json.loads(_tool_check_update({}, None))
+        assert result["up_to_date"] is True
+        assert result["version"] == "abc1234"
+
+    def test_update_available(self, tmp_path):
+        from bot.core import _tool_check_update
+        version_file = tmp_path / ".state" / "woltspace-version"
+        version_file.parent.mkdir(parents=True)
+        version_file.write_text("oldcommit1234567890")
+
+        mock_result = MagicMock()
+        mock_result.stdout = "newcommit9876543210\trefs/heads/main\n"
+
+        with patch("bot.core.WOLT_DIR", tmp_path), \
+             patch("subprocess.run", return_value=mock_result):
+            result = json.loads(_tool_check_update({}, None))
+        assert result["up_to_date"] is False
+        assert result["local"] == "oldcomm"
+        assert result["remote"] == "newcomm"
+        assert "update is available" in result["message"]
+
+    def test_first_run_initializes_version(self, tmp_path):
+        from bot.core import _tool_check_update
+        # No version file exists yet
+        mock_result = MagicMock()
+        mock_result.stdout = "abc1234567890\trefs/heads/main\n"
+
+        with patch("bot.core.WOLT_DIR", tmp_path), \
+             patch("subprocess.run", return_value=mock_result):
+            result = json.loads(_tool_check_update({}, None))
+        assert result["up_to_date"] is True
+        assert "initialized" in result.get("note", "")
+        # Version file should now exist
+        assert (tmp_path / ".state" / "woltspace-version").read_text() == "abc1234567890"
+
+    def test_remote_unreachable(self, tmp_path):
+        from bot.core import _tool_check_update
+        mock_result = MagicMock()
+        mock_result.stdout = ""
+
+        with patch("bot.core.WOLT_DIR", tmp_path), \
+             patch("subprocess.run", return_value=mock_result):
+            result = json.loads(_tool_check_update({}, None))
+        assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Notify footer (from server/notify.py)
+# ---------------------------------------------------------------------------
+
+class TestNotifyFooter:
+    """Unit: session footer is skipped for sessionless notifications."""
+
+    def test_footer_skipped_when_no_session(self):
+        """Empty session should produce no footer."""
+        # We test the logic directly rather than calling the async function
+        session = ""
+        footer = ""
+        if session:
+            footer = f"\n\n---reply footer\n/tui?session={session}"
+        assert footer == ""
+
+    def test_footer_present_when_session_exists(self):
+        """Non-empty session should produce a footer."""
+        session = "beaver-chunky-dam-abc123"
+        footer = ""
+        if session:
+            footer = f"\n\n---reply footer\n/tui?session={session}"
+        assert "beaver-chunky-dam-abc123" in footer
+        assert footer != ""

--- a/woltspace
+++ b/woltspace
@@ -6,7 +6,9 @@
 #   woltspace start          — start container (all wolts mounted)
 #   woltspace stop           — stop and remove container
 #   woltspace restart        — restart container (new tunnel URL)
-#   woltspace rebuild        — rebuild image + restart
+#   woltspace rebuild        — rebuild image from main + restart
+#   woltspace rebuild --dev  — rebuild image from staging + restart
+#   woltspace update         — check if a new version is available
 #   woltspace list           — list all wolts (name, type, role)
 #   woltspace shell          — enter running container
 #   woltspace chat           — open claude (--dangerously-skip-permissions) in container
@@ -511,12 +513,87 @@ case "$cmd" in
     exit 0
     ;;
   rebuild)
+    _D=$'\033[2m'; _R=$'\033[0m'; _B=$'\033[1m'; _G=$'\033[0;32m'; _Y=$'\033[0;33m'
+
+    # Determine which branch to build from
+    BUILD_BRANCH="main"
+    for arg in "$@"; do
+      [ "$arg" = "--dev" ] && BUILD_BRANCH="staging"
+    done
+
+    # Save current branch to restore after build
+    CURRENT_BRANCH=$(cd "$WOLTSPACE_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev/null)
+
+    # Checkout the target branch
+    if [ "$BUILD_BRANCH" != "$CURRENT_BRANCH" ]; then
+      echo "  switching to ${_B}${BUILD_BRANCH}${_R} branch..."
+      (cd "$WOLTSPACE_DIR" && git fetch origin "$BUILD_BRANCH" 2>/dev/null && git checkout "$BUILD_BRANCH" && git pull origin "$BUILD_BRANCH") || {
+        echo "  error: could not checkout $BUILD_BRANCH"
+        exit 1
+      }
+    else
+      echo "  already on ${_B}${BUILD_BRANCH}${_R}, pulling latest..."
+      (cd "$WOLTSPACE_DIR" && git pull origin "$BUILD_BRANCH" 2>/dev/null) || true
+    fi
+
+    if [ "$BUILD_BRANCH" = "staging" ]; then
+      printf "  building from ${_Y}staging${_R} (latest, may be rough)\n"
+    else
+      printf "  building from ${_G}main${_R} (stable)\n"
+    fi
+
     docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
     rm -f "$ACTIVE_WOLT_DIR/.state/tunnel-url"
     docker build -t woltspace -f "$WOLTSPACE_DIR/container/Dockerfile" "$WOLTSPACE_DIR"
+
+    # Stamp the version so the update-check cron knows what we're running
+    BUILD_COMMIT=$(cd "$WOLTSPACE_DIR" && git rev-parse HEAD 2>/dev/null)
+    if [ -n "$BUILD_COMMIT" ]; then
+      mkdir -p "$ACTIVE_WOLT_DIR/.state"
+      echo "$BUILD_COMMIT" > "$ACTIVE_WOLT_DIR/.state/woltspace-version"
+    fi
+
     _ensure_container "$CONTAINER_NAME"
     echo "  open the link above in your browser."
     echo ""
+    exit 0
+    ;;
+  update)
+    _D=$'\033[2m'; _R=$'\033[0m'; _B=$'\033[1m'; _G=$'\033[0;32m'; _Y=$'\033[0;33m'
+
+    echo ""
+    echo "  checking for updates..."
+
+    # Fetch latest from remote
+    (cd "$WOLTSPACE_DIR" && git fetch origin main 2>/dev/null) || {
+      echo "  error: could not reach remote — check your connection"
+      exit 1
+    }
+
+    LOCAL_HEAD=$(cd "$WOLTSPACE_DIR" && git rev-parse main 2>/dev/null)
+    REMOTE_HEAD=$(cd "$WOLTSPACE_DIR" && git rev-parse origin/main 2>/dev/null)
+
+    if [ "$LOCAL_HEAD" = "$REMOTE_HEAD" ]; then
+      printf "  ${_G}you're up to date.${_R}\n"
+      echo ""
+      LOCAL_SHORT=$(echo "$LOCAL_HEAD" | cut -c1-7)
+      printf "  ${_D}main @ %s${_R}\n" "$LOCAL_SHORT"
+      echo ""
+    else
+      # Count commits behind
+      BEHIND=$(cd "$WOLTSPACE_DIR" && git rev-list --count main..origin/main 2>/dev/null)
+      printf "  ${_Y}update available${_R} — %s commit(s) behind\n" "$BEHIND"
+      echo ""
+      # Show what changed
+      printf "  ${_D}recent changes:${_R}\n"
+      (cd "$WOLTSPACE_DIR" && git log --oneline main..origin/main | head -10 | while read -r line; do
+        printf "    ${_D}%s${_R}\n" "$line"
+      done)
+      echo ""
+      printf "  to update, ask a beaver or raccoon:\n"
+      printf "    ${_D}\"can you update woltspace?\"${_R}\n"
+      echo ""
+    fi
     exit 0
     ;;
   start)
@@ -530,7 +607,7 @@ case "$cmd" in
     echo ""
     ;;
   *)
-    echo "usage: woltspace <init|start|stop|restart|rebuild|list|shell|chat|logs> [--wolt=<name>] [--no-dev]"
+    echo "usage: woltspace <init|start|stop|restart|rebuild|update|list|shell|chat|logs> [--wolt=<name>] [--no-dev]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Promotes the staging batch to main. This is the first staging → main merge, establishing the two-branch workflow.

**What's shipping:**
- **Two-branch model** — `rebuild` builds from main (stable), `rebuild --dev` from staging
- **`woltspace update`** — CLI command to check for new versions
- **Daily update checker cron** — no-LLM `check-update.sh` notifies when an update lands
- **`check_update` dog tool** — dog can answer "is there an update?" inline
- **wolf.json seeding** — existing users get the update checker on next boot
- **Sessionless notify fix** — wolf/system notifications no longer get a broken session footer

8 commits, 14 files, 438 lines added. All tests pass (51).

## Test plan
- [x] 51 wolf tests pass
- [ ] `woltspace rebuild` builds from main
- [ ] `woltspace rebuild --dev` builds from staging
- [ ] `woltspace update` shows correct status
- [ ] Dog `check_update` reports correctly in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)