### PR TITLE
Merge staging: always-mount repo + responsible updater

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,10 +103,12 @@ Development workflow: `wt create feature-name` → work → PR to staging → me
 Updates are opt-in, never automatic:
 1. A **wolf cron** (`check-update.sh`) runs daily, compares local version against remote `main` using `git ls-remote`. If behind, sends a 🐺 notification: *"update available — ask a beaver or raccoon to update."*
 2. The **dog** has a `check_update` tool — when asked "is there an update?", it checks inline and reports.
-3. User asks a **rodent** (beaver/raccoon) to handle the update. The rodent evaluates the diff, explains impact, and only proceeds with user consent.
+3. User asks a **rodent** (beaver/raccoon) to handle the update. Use the `/update` skill — it reviews incoming changes, flags breaking changes or new requirements, and only pulls after user consent.
 4. `woltspace update` on the host shows the same info (commits behind + changelog).
 
-Version tracking: `.state/woltspace-version` stores the commit hash after each `rebuild`.
+**How the update works from inside the container:** `/workspace/woltspace` is always volume-mounted from the host. So `git pull` updates files live — no container rebuild needed. The `/update` skill reads `.state/woltspace-branch` to know which branch to pull (`main` by default, `staging` in dev mode). After pulling, it stamps `.state/woltspace-version` with the new commit so the update-check cron knows it's current.
+
+Version tracking: `.state/woltspace-version` stores the commit hash — written by `woltspace rebuild` on the host, or by the `/update` skill after a pull.
 
 ### `server.js` (Node.js, ~1400 lines)
 Single-file HTTP + WebSocket server running on port 3000 inside the container.
@@ -349,7 +351,7 @@ To test staging locally: `woltspace rebuild --dev` (builds from staging instead 
 
 ### Dev mode
 
-This repo is usually mounted into the container in dev mode (`woltspace start` auto-detects if you're in the repo and enables dev mode). The server runs with `node --watch` — save `server.js` and it restarts. The bot does NOT auto-restart; kill and relaunch it manually after edits.
+The woltspace repo is always mounted into the container at `/workspace/woltspace`. Dev mode (`woltspace start --dev`) tracks the `staging` branch instead of `main` — the update checker and `/update` skill will compare against and pull from staging. The server runs with `node --watch` — save `server.js` and it restarts. The bot does NOT auto-restart; kill and relaunch it manually after edits.
 
 Restart Telegram bot:
 ```bash

--- a/container/skills/update/SKILL.md
+++ b/container/skills/update/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: update
+description: "Update woltspace platform — review incoming changes, warn about breaking changes, and pull with user consent. Use when asked to update woltspace."
+user_invocable: true
+---
+
+# Update Woltspace
+
+You are the responsible updater. Your job is to protect the user — review what's coming, flag anything risky, and only pull with explicit consent.
+
+`/workspace/woltspace` is volume-mounted from the host, so `git pull` updates files live — no rebuild needed.
+
+## Step 1: Determine what's incoming
+
+```bash
+WOLT_DIR="${WOLT_DIR:-/workspace/wolts/${WOLT_NAME:-wolt}}"
+BRANCH=$(cat "$WOLT_DIR/.state/woltspace-branch" 2>/dev/null || echo "main")
+
+cd /workspace/woltspace
+git fetch origin "$BRANCH"
+```
+
+Check if there's actually anything new:
+```bash
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse "origin/$BRANCH")
+```
+
+If they match, tell the user they're already up to date and stop.
+
+## Step 2: Review the changes
+
+Look at what's incoming:
+```bash
+git log --oneline HEAD..origin/$BRANCH
+git diff --stat HEAD..origin/$BRANCH
+```
+
+Read the actual diff for anything that looks like it could break existing behavior. Focus on:
+
+- **Config/env changes** — new required env vars, renamed vars, changed defaults
+- **Removed or renamed files** — skills, cron scripts, bot tools that wolts might depend on
+- **CLAUDE.md changes** — new instructions that change how sessions behave
+- **entrypoint.sh changes** — startup behavior, process management
+- **woltspace CLI changes** — flag changes, new required args
+- **Database/state format changes** — .state files, woltspace.json schema changes
+- **Bot behavior changes** — tool renames, removed capabilities, changed routing
+
+If a merge PR exists for the incoming commits, read it for context. Check if there's a changelog or migration notes.
+
+## Step 3: Report to the user
+
+Send a notify with your assessment. Structure it as:
+
+**If safe (no breaking changes):**
+> X commits incoming on [branch]. [1-2 sentence summary of what's new]. No breaking changes — safe to pull. Want me to update?
+
+**If there are concerns:**
+> X commits incoming on [branch]. [summary of what's new]. Heads up: [specific concern — e.g. "new OPENAI_API_KEY env var required for image gen" or "wolf skill renamed, existing wolf crons may need reconfiguring"]. Want me to proceed anyway?
+
+Be specific about what might break. Don't just say "there are breaking changes" — say exactly what and what the user would need to do.
+
+## Step 4: Pull (only after user says yes)
+
+Do NOT pull until the user explicitly confirms. Then:
+
+```bash
+cd /workspace/woltspace && git pull origin "$BRANCH"
+
+# Stamp version
+NEW_VERSION=$(git rev-parse HEAD)
+mkdir -p "$WOLT_DIR/.state"
+echo "$NEW_VERSION" > "$WOLT_DIR/.state/woltspace-version"
+echo "$BRANCH" > "$WOLT_DIR/.state/woltspace-branch"
+```
+
+## Step 5: Post-update report
+
+After pulling:
+```bash
+git log --oneline ORIG_HEAD..HEAD
+```
+
+Notify the user with: what was updated, the new version hash, and any action items (e.g. "bot behavior changed — restart the bot to pick it up").
+
+## Notes
+
+- `woltspace rebuild` is a **host-only** command — no docker CLI inside the container
+- `server.js` runs with `--watch` so it picks up file changes automatically
+- The Telegram bot does NOT auto-restart — if bot code changed, tell the user to restart manually
+- If the update includes new env vars, tell the user to add them to `~/wolts/.env`
+- If entrypoint.sh changed, a container restart may be needed — flag this

--- a/woltspace
+++ b/woltspace
@@ -4,6 +4,7 @@
 # Usage:
 #   woltspace init           — create a new wolt
 #   woltspace start          — start container (all wolts mounted)
+#   woltspace start --dev    — start in dev mode (tracks staging branch)
 #   woltspace stop           — stop and remove container
 #   woltspace restart        — restart container (new tunnel URL)
 #   woltspace rebuild        — rebuild image from main + restart
@@ -30,10 +31,10 @@ WOLTS_DIR="${WOLTS_DIR/#\~/$HOME}"
 cmd="${1:-start}"
 
 # Parse flags
-DEV_MODE=true
+DEV_MODE=false
 WOLT_OVERRIDE=""
 for arg in "$@"; do
-  [ "$arg" = "--no-dev" ] && DEV_MODE=false
+  [ "$arg" = "--dev" ] && DEV_MODE=true
   [[ "$arg" == --wolt=* ]] && WOLT_OVERRIDE="${arg#--wolt=}"
 done
 
@@ -113,10 +114,8 @@ _ensure_container() {
     local oauth_token
     oauth_token=$(grep '^CLAUDE_CODE_OAUTH_TOKEN=' "$env_file" 2>/dev/null | cut -d= -f2-)
 
-    local dev_mounts=""
     if [ "$DEV_MODE" = true ]; then
-      dev_mounts="-v $WOLTSPACE_DIR:/workspace/woltspace:rw"
-      echo "  dev mode: woltspace repo mounted at /workspace/woltspace"
+      echo "  dev mode: tracking staging branch"
     fi
 
     docker run -d \
@@ -124,11 +123,12 @@ _ensure_container() {
       --env-file "$env_file" \
       -v "$WOLTS_DIR:/workspace/wolts:rw" \
       -v "$WOLTS_DIR/.claude:/home/node/.claude:rw" \
+      -v "$WOLTSPACE_DIR:/workspace/woltspace:rw" \
       $deploy_key_mount \
-      $dev_mounts \
       -p 4444:3000 \
       -e WOLTS_DIR=/workspace/wolts \
       -e WOLT_NAME="$ACTIVE_WOLT" \
+      -e DEV_MODE="$DEV_MODE" \
       -e CLAUDE_CODE_OAUTH_TOKEN="$oauth_token" \
       woltspace > /dev/null
 
@@ -608,7 +608,7 @@ case "$cmd" in
     echo ""
     ;;
   *)
-    echo "usage: woltspace <init|start|stop|restart|rebuild|update|list|shell|chat|logs> [--wolt=<name>] [--no-dev]"
+    echo "usage: woltspace <init|start|stop|restart|rebuild|update|list|shell|chat|logs> [--wolt=<name>] [--dev]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
## Summary

Promotes staging to main. Ships the update system that actually works for regular users.

- **Always mount woltspace repo** — not just in dev mode. Every container gets git access, so `/update` works for everyone
- **Dev mode is now a branch selector** — `--dev` tracks staging, default tracks main. Mount and watch behavior unchanged
- **`/update` is a responsible updater** — reviews incoming diff, flags breaking changes (env vars, removed files, config shifts, bot behavior), reports to user, only pulls after explicit consent

### The update flow (end to end)

1. Wolf cron detects update → notifies user
2. Dog can also check inline when asked
3. User asks a rodent → rodent runs `/update` → reviews changes → reports findings → waits for consent → pulls → post-update report

### Commits

- Flip dev mode default: off by default, `--dev` to enable
- Always mount woltspace repo — updates work for all users, not just dev mode
- Make `/update` a responsible updater — review changes before pulling