### PR TITLE
Fix rebuild --dev to checkout staging without pulling

### DIFF
--- a/woltspace
+++ b/woltspace
@@ -523,9 +523,14 @@ case "$cmd" in
 
     CURRENT_BRANCH=$(cd "$WOLTSPACE_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
-    # Warn if checkout doesn't match expected branch
+    # --dev: checkout staging (but don't pull — let rodents handle updates)
     if [ "$BUILD_BRANCH" != "$CURRENT_BRANCH" ]; then
-      printf "  ${_Y}note:${_R} on ${_B}%s${_R} but tracking ${_B}%s${_R} for updates\n" "$CURRENT_BRANCH" "$BUILD_BRANCH"
+      echo "  switching to ${_B}${BUILD_BRANCH}${_R}..."
+      (cd "$WOLTSPACE_DIR" && git fetch origin "$BUILD_BRANCH" 2>/dev/null && git checkout "$BUILD_BRANCH") || {
+        echo "  error: could not checkout $BUILD_BRANCH"
+        exit 1
+      }
+      CURRENT_BRANCH="$BUILD_BRANCH"
     fi
 
     printf "  rebuilding image from current checkout ${_D}(%s)${_R}\n" "$CURRENT_BRANCH"


### PR DESCRIPTION
## The --dev flag forgot how to swim to staging 🦫

After removing the blind pull from rebuild (#44), `--dev` stopped switching branches entirely — it just warned "on main but tracking staging" and built from main. A dev who says `--dev` expects staging code.

## The fix

`--dev` now does `git fetch + git checkout staging` (no pull). You get the staging branch at whatever commit you last pulled — if you want the latest staging code, ask a rodent. Same update story as main, just pointed at a different stream.

**Behavior summary:**
- `woltspace rebuild` — builds from current checkout, no switch, no pull
- `woltspace rebuild --dev` — checks out staging (fetch + checkout, no pull), builds from there

## Test plan
- [ ] `rebuild --dev` from main → switches to staging, builds, no pull
- [ ] `rebuild` (no flag) on main → stays on main, builds, no pull
- [ ] Post-build update nudge still works when behind remote

*`--dev` finds the staging stream again* 🦫

🤖 Generated with [Claude Code](https://claude.com/claude-code)