### PR TITLE
Merge staging: --dev remembers where staging lives

### DIFF
--- a/woltspace
+++ b/woltspace
@@ -523,9 +523,14 @@ case "$cmd" in
 
     CURRENT_BRANCH=$(cd "$WOLTSPACE_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev/null)
 
-    # Warn if checkout doesn't match expected branch
+    # --dev: checkout staging (but don't pull — let rodents handle updates)
     if [ "$BUILD_BRANCH" != "$CURRENT_BRANCH" ]; then
-      printf "  ${_Y}note:${_R} on ${_B}%s${_R} but tracking ${_B}%s${_R} for updates\n" "$CURRENT_BRANCH" "$BUILD_BRANCH"
+      echo "  switching to ${_B}${BUILD_BRANCH}${_R}..."
+      (cd "$WOLTSPACE_DIR" && git fetch origin "$BUILD_BRANCH" 2>/dev/null && git checkout "$BUILD_BRANCH") || {
+        echo "  error: could not checkout $BUILD_BRANCH"
+        exit 1
+      }
+      CURRENT_BRANCH="$BUILD_BRANCH"
     fi
 
     printf "  rebuilding image from current checkout ${_D}(%s)${_R}\n" "$CURRENT_BRANCH"


### PR DESCRIPTION
## The --dev flag lost its way 🦫

After #44 removed the blind pull from rebuild, `--dev` forgot how to switch branches entirely — it stayed on main and just stamped "staging" for the tracker. A dev asking for `--dev` expects staging code, not a note saying "tracking staging."

## The fix

`--dev` now does `git fetch + git checkout staging` (no pull). You get staging at whatever commit you last had — if you want latest, a rodent handles that in-app. Same update story, both branches.

**Behavior now:**
- `woltspace rebuild` — builds from current checkout, no switch, no pull
- `woltspace rebuild --dev` — checks out staging (no pull), builds from there
- Both check for updates after build and nudge if behind

### Commit
- Fix rebuild --dev to checkout staging (without pulling)

*every stream leads somewhere — `--dev` finds staging again* 🦫

🤖 Generated with [Claude Code](https://claude.com/claude-code)