### PR TITLE
Wolf sees itself — howlie speaks as howlie

### DIFF
--- a/container/creatures/wolf.py
+++ b/container/creatures/wolf.py
@@ -17,12 +17,48 @@ Usage:
 import asyncio
 import json
 import os
+import secrets
 import subprocess
 import sys
 import time
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+
+# ── Cached helpers ─────────────────────────────────────────────────
+
+_wolf_name_cache: Optional[str] = None
+
+
+def _get_wolf_name() -> str:
+    """Read wolf name from wolt.json, cached after first call."""
+    global _wolf_name_cache
+    if _wolf_name_cache is not None:
+        return _wolf_name_cache
+    try:
+        wolt_json = get_wolt_dir() / "wolt" / "wolt.json"
+        data = json.loads(wolt_json.read_text())
+        _wolf_name_cache = data.get("name", "wolf")
+    except Exception:
+        _wolf_name_cache = "wolf"
+    return _wolf_name_cache
+
+
+def _get_tunnel_url() -> Optional[str]:
+    """Read tunnel URL from .state/tunnel-url."""
+    wolts_dir = Path(os.environ.get("WOLTS_DIR", "/workspace/wolts"))
+    tunnel_file = wolts_dir / ".state" / "tunnel-url"
+    if tunnel_file.exists():
+        url = tunnel_file.read_text().strip()
+        return url if url else None
+    return None
+
+
+def _make_session_name(cron_name: str) -> str:
+    """Generate a tmux session name: {wolf}-{cron}-{hex6}."""
+    wolf = _get_wolf_name()
+    hex6 = secrets.token_hex(3)
+    return f"{wolf}-{cron_name}-{hex6}"
 
 # ── Cron expression parser (minimal, no deps) ──────────────────────
 
@@ -179,8 +215,8 @@ def set_last_run(name: str, dt: datetime):
 
 def send_wolf_notify(message: str):
     """Send a 🐺 wolf notification via the server."""
-    wolt_name = os.environ.get("WOLT_NAME", "wolt")
-    full_message = f"🐺 {wolt_name}: {message}"
+    wolf_name = _get_wolf_name()
+    full_message = f"🐺 {wolf_name}: {message}"
 
     # Use the notify endpoint directly (no session context needed)
     payload = json.dumps({"message": full_message, "session": ""})
@@ -201,34 +237,57 @@ def send_wolf_notify(message: str):
         print(f"[wolf] notify error: {e}", file=sys.stderr)
 
 
-def run_script(entry: dict):
-    """Run a shell command."""
+def run_script(entry: dict) -> Optional[str]:
+    """Run a shell command inside a tmux session. Returns session name."""
     command = entry.get("command", "")
+    cron_name = entry.get("name", "script")
     if not command:
-        print(f"[wolf] {entry['name']}: no command specified", file=sys.stderr)
-        return
+        print(f"[wolf] {cron_name}: no command specified", file=sys.stderr)
+        return None
 
-    print(f"[wolf] running script: {command}")
-    env = {**os.environ}
+    session_name = _make_session_name(cron_name)
+    wolt_dir = str(get_wolt_dir())
+    wolf_name = _get_wolf_name()
+
+    # Build notification JSON payloads (avoid shell quoting hell by using heredocs)
+    ok_msg = f"🐺 {wolf_name}: cron '{cron_name}' completed successfully"
+    fail_prefix = f"🐺 {wolf_name}: cron '{cron_name}' failed (exit "
+    notify_url = "http://localhost:3000/notify"
+
+    # Wrap: run command, capture exit code, notify completion, keep terminal open
+    wrapped = (
+        f"{command}; _exit=$?; "
+        f"_notify() {{ curl -s -X POST {notify_url} -H 'Content-Type: application/json' "
+        f"""-d "$(printf '{{"message":"%s","session":""}}' "$1")"; }}; """
+        f'if [ "$_exit" -eq 0 ]; then '
+        f'  _notify "{ok_msg}"; '
+        f"else "
+        f'  _notify "{fail_prefix}$_exit)"; '
+        f"fi; "
+        f"exec bash"
+    )
+
+    print(f"[wolf] running script in tmux session: {session_name}")
     try:
-        subprocess.Popen(
-            command,
-            shell=True,
-            env=env,
-            start_new_session=True,
+        subprocess.run(
+            ["tmux", "new-session", "-d", "-s", session_name, "-c", wolt_dir,
+             "bash", "-c", wrapped],
+            check=True, capture_output=True, text=True, timeout=10,
         )
+        return session_name
     except Exception as e:
         print(f"[wolf] script error: {e}", file=sys.stderr)
-        send_wolf_notify(f"cron '{entry['name']}' failed: {e}")
+        send_wolf_notify(f"cron '{cron_name}' failed to start: {e}")
+        return None
 
 
-def run_session(entry: dict):
-    """Dispatch a Claude Code session via the bot's API."""
+def run_session(entry: dict) -> Optional[str]:
+    """Dispatch a Claude Code session via the bot's API. Returns session URL if available."""
     prompt = entry.get("prompt", "")
     creature = entry.get("creature", "beaver")
     if not prompt:
         print(f"[wolf] {entry['name']}: no prompt specified", file=sys.stderr)
-        return
+        return None
 
     print(f"[wolf] dispatching {creature} session: {prompt[:80]}")
 
@@ -246,9 +305,22 @@ def run_session(entry: dict):
             capture_output=True, text=True, timeout=10,
         )
         print(f"[wolf] session response: {result.stdout[:200]}")
+        # Parse response for session name/URL
+        resp = json.loads(result.stdout) if result.stdout else {}
+        session_name = resp.get("name")
+        session_url = resp.get("url")
+        if session_url:
+            return session_url
+        elif session_name:
+            # Construct URL from tunnel
+            tunnel_url = _get_tunnel_url()
+            if tunnel_url:
+                return f"{tunnel_url}/?session={session_name}"
+        return None
     except Exception as e:
         print(f"[wolf] session dispatch error: {e}", file=sys.stderr)
         send_wolf_notify(f"cron '{entry['name']}' failed to dispatch: {e}")
+        return None
 
 
 def run_skill(entry: dict):
@@ -262,24 +334,32 @@ def run_skill(entry: dict):
 
 
 def fire_cron(entry: dict):
-    """Execute a cron entry."""
+    """Execute a cron entry — fire action first, then notify with link."""
     name = entry.get("name", "unnamed")
     action = entry.get("action", "script")
     notify_msg = entry.get("notify")
 
-    # Send notification first (deterministic, immediate)
-    if notify_msg:
-        send_wolf_notify(notify_msg)
-
-    # Execute the action
+    # Fire action first (to get session name/URL)
+    link = None
     if action == "script":
-        run_script(entry)
+        session_name = run_script(entry)
+        if session_name:
+            tunnel_url = _get_tunnel_url()
+            if tunnel_url:
+                link = f"{tunnel_url}/?session={session_name}"
     elif action == "session":
-        run_session(entry)
+        link = run_session(entry)
     elif action == "skill":
         run_skill(entry)
     else:
         print(f"[wolf] {name}: unknown action '{action}'", file=sys.stderr)
+
+    # Send notification with link appended
+    if notify_msg:
+        msg = notify_msg
+        if link:
+            msg = f"{msg}\n{link}"
+        send_wolf_notify(msg)
 
 
 # ── Main loop ───────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

The wolf was wearing neowolt's name tag and firing crons into the void. Three fixes, one file:

- **Identity**: `_get_wolf_name()` reads from `wolt.json` (cached) — notifications say "howlie" not "neowolt"
- **Visibility**: Scripts launch in named tmux sessions (`howlie-digest-{hex6}`) that stay open after completion via `exec bash`
- **Feedback loop**: Fire action *first*, then notify with session URL. Wolf self-reports completion/failure when the job finishes.

## What changed

`container/creatures/wolf.py` — added 3 helpers (`_get_wolf_name`, `_get_tunnel_url`, `_make_session_name`), rewrote `run_script` (tmux), updated `run_session` (parse response URL), flipped `fire_cron` ordering (action → notify with link).

## Test plan

- [ ] `python -m creatures.wolf --fire digest` → tmux session `howlie-digest-{hex}` appears
- [ ] `tmux ls` shows the session
- [ ] Notification says "howlie" not "neowolt"
- [ ] Notification includes clickable session URL
- [ ] On script completion, second notification: "cron 'digest' completed successfully"
- [ ] Terminal stays open after script exits

🐺 Generated with [Claude Code](https://claude.com/claude-code)