### PR TITLE
fix digest not pushing to viewport

### DIFF
--- a/container/cron/digest.mjs
+++ b/container/cron/digest.mjs
@@ -8,7 +8,6 @@
 import { readFileSync, existsSync, readdirSync, writeFileSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
-import { request as httpRequest } from 'node:http';
 import { randomBytes } from 'node:crypto';
 import { spawn as spawnProcess } from 'node:child_process';
 
@@ -218,15 +217,11 @@ function recentSparks(n = 4) {
 // -- Push to right pane --
 
 function pushToPane(sparkId) {
+  // Use push-view so session routing works correctly (reads WOLT_SESSION / tmux)
   return new Promise((resolve, reject) => {
-    const body = JSON.stringify({ url: '/history/' + sparkId });
-    const req = httpRequest({
-      host: 'localhost', port: 3000, path: '/current', method: 'POST',
-      headers: { 'Content-Type': 'application/json', 'Content-Length': Buffer.byteLength(body) },
-    }, res => { res.resume(); res.on('end', resolve); });
-    req.on('error', reject);
-    req.write(body);
-    req.end();
+    const proc = spawnProcess('push-view', ['/history/' + sparkId]);
+    proc.on('close', resolve);
+    proc.on('error', reject);
   });
 }
 

--- a/container/skills/wolf/SKILL.md
+++ b/container/skills/wolf/SKILL.md
@@ -107,6 +107,13 @@ Examples:
 { "action": "script", "command": "node /path/to/script.js" }
 ```
 
+If your script produces something visual (an HTML page, a spark), push it to the viewport with `push-view`:
+```bash
+push-view /history/SPARK_ID      # for sparks
+push-view /your-page.html        # for static pages in wolt/site/
+```
+`push-view` auto-detects the current session — just call it at the end of the script. Scripts that omit this will silently set the viewport on the wrong session.
+
 ### `session` — spawn a Claude Code session
 ```json
 { "action": "session", "prompt": "do the thing", "creature": "beaver" }


### PR DESCRIPTION
## Root cause

`pushToPane` in `digest.mjs` was posting to `/current` with no `?session=` query param. The server defaults to session `main` when the param is missing, so the digest page was landing in the wrong pane — not the session running the digest.

## Fix

`push-view` already solves this correctly: reads `WOLT_SESSION` env var first, falls back to `tmux display-message -p '#S'`, then posts to `/current?session=X`. Swapped the custom inline HTTP call for a `push-view` subprocess call and dropped the now-unused `httpRequest` import.

## Why it wasn't caught sooner

The digest completed and notified successfully — it just silently set the viewport on the wrong session. No error, no log noise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)