### PR TITLE
Add Windows prereqs + WSL note to landing page

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -31,6 +31,11 @@
       <code>curl -fsSL https://woltspace.com/install.sh | bash</code>
       <button class="copy-btn" onclick="copyInstall()">Copy</button>
     </section>
+    <p class="prereqs">requires <a href="https://docs.docker.com/get-docker/" target="_blank" rel="noopener">Docker Desktop</a> · git</p>
+    <details class="windows-note">
+      <summary>Windows?</summary>
+      <p>Open WSL (Ubuntu) — not PowerShell or cmd. No WSL yet? Run <code>wsl --install</code> in PowerShell as admin, reboot, then paste the command in the Ubuntu terminal. Docker Desktop handles the rest automatically once WSL integration is enabled.</p>
+    </details>
     <p class="github-line"><a class="github-link" href="https://github.com/jerpint/woltspace">GitHub</a></p>
 
     <section>

--- a/site/style.css
+++ b/site/style.css
@@ -266,6 +266,47 @@ footer a {
   background: #444;
 }
 
+.prereqs {
+  font-size: 0.85rem;
+  color: #888;
+  margin-top: -1rem;
+  margin-bottom: 0.25rem;
+}
+
+.prereqs a {
+  color: #888;
+  text-decoration-color: #ccc;
+}
+
+.windows-note {
+  font-size: 0.85rem;
+  color: #888;
+  margin-bottom: 0;
+}
+
+.windows-note summary {
+  cursor: pointer;
+  color: #888;
+  text-decoration: underline;
+  text-decoration-color: #ccc;
+  text-underline-offset: 2px;
+  user-select: none;
+  display: inline;
+}
+
+.windows-note summary:hover {
+  color: #555;
+  text-decoration-color: #888;
+}
+
+.windows-note p {
+  margin-top: 0.5rem;
+  margin-bottom: 0;
+  color: #666;
+  padding-left: 0.75rem;
+  border-left: 2px solid #e0e0e0;
+}
+
 
 /* Network messages */
 .network-section {


### PR DESCRIPTION
## What

A beaver noticed the pond had no sign for Windows wanderers.

Adds two small things below the install one-liner:
- `requires Docker Desktop · git` — links to Docker docs, muted so it doesn't compete with the command
- `Windows?` — collapsed `<details>` element, invisible unless you need it. Expands to: open WSL (Ubuntu), not PowerShell; and the `wsl --install` one-liner for anyone starting from scratch. Docker Desktop handles WSL integration automatically once it's enabled.

## Why

Onboarding a Windows user — the paste target (WSL terminal vs PowerShell) isn't obvious and `wsl --install` is a one-time prereq that's easy to miss.

## What it looks like

Collapsed (Mac/Linux users see nothing extra):
```
curl -fsSL https://woltspace.com/install.sh | bash   [Copy]
requires Docker Desktop · git
Windows? ▶
```

Expanded:
```
Windows? ▼
  Open WSL (Ubuntu) — not PowerShell or cmd. No WSL yet?
  Run wsl --install in PowerShell as admin, reboot, then
  paste in the Ubuntu terminal. Docker Desktop handles the
  rest automatically once WSL integration is enabled.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)