### PR TITLE
install.sh: stop rm-rf'ing the lodge, warn on dirty pull

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -6,11 +6,13 @@ command -v git >/dev/null || { echo "error: git required"; exit 1; }
 
 if [ -d "woltspace/.git" ]; then
   echo "  woltspace already cloned — pulling latest..."
-  git -C woltspace pull --ff-only
+  git -C woltspace fetch --quiet
+  git -C woltspace merge --ff-only FETCH_HEAD || {
+    echo "  warning: local changes detected — skipping pull. Run 'git -C woltspace pull' manually."
+  }
 elif [ -d "woltspace" ]; then
-  echo "  woltspace directory exists but isn't a git repo — removing and re-cloning..."
-  rm -rf woltspace
-  git clone https://github.com/jerpint/woltspace
+  echo "error: ./woltspace exists but isn't a git repo — remove it manually and re-run"
+  exit 1
 else
   git clone https://github.com/jerpint/woltspace
 fi


### PR DESCRIPTION
## The trouble at the gate

A scout arrives at the lodge and finds a directory called \`woltspace\` — but it's not a git repo. The old installer's response: burn it down, clone fresh, say nothing. No warning. No confirmation. Gone.

That's not a guest's behavior.

## What changed

- **Clause 2** (\`woltspace\` dir exists, no \`.git\`): removed the silent \`rm -rf\`. Now prints an error and exits — the human cleans it up themselves.
- **Clause 1** (\`woltspace/.git\` exists): replaced \`--ff-only\` hard-fail with \`fetch\` + conditional \`merge --ff-only\`. Dirty state now prints a warning and lets the install continue instead of aborting everything.
- Clause 3 (clean state → clone): untouched.

## Test plan

- [ ] Run install in a clean dir — should clone and proceed to \`woltspace init\`
- [ ] Run install when \`woltspace/.git\` exists and is up to date — should say "already cloned" and continue
- [ ] Run install when \`woltspace/.git\` exists with local uncommitted changes — should warn, not abort
- [ ] Run install when \`./woltspace\` exists without \`.git\` — should error and exit 1

🦫 the installer is a guest, not a demolisher

🤖 Generated with [Claude Code](https://claude.com/claude-code)