### PR TITLE
Add immediate dog ack for Telegram messages

### DIFF
--- a/container/bot/telegram_adapter.py
+++ b/container/bot/telegram_adapter.py
@@ -8,11 +8,13 @@ import json
 import base64
 import logging
 import asyncio
+import random
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 from collections import defaultdict
 from telegram import Update
+from telegram.constants import ChatAction
 from telegram.ext import ApplicationBuilder, MessageHandler, CommandHandler, filters, ContextTypes
 import re
 from bot.core import get_response, transcribe_audio, list_sessions, kill_session, get_tunnel_url, switch_wolt, list_wolts, _bot_log, build_ack_text, _sanitize_history, message_session
@@ -37,6 +39,23 @@ def _dog_name() -> str:
 ALLOWED_USERS: set[int] = set()
 chat_histories: dict[int, list] = defaultdict(list)
 MAX_HISTORY = 20
+
+# Immediate ack messages — sent before processing starts so the user knows we heard them
+DOG_ACK_MESSAGES = [
+    "🐶 on it...",
+    "🐶 sniffing...",
+    "🐶 heard you",
+    "🐶 *perks ears*",
+    "🐶 one sec...",
+]
+
+
+async def _dog_ack(update: Update):
+    """Fire an immediate acknowledgment so the user knows the message landed."""
+    try:
+        await update.message.reply_text(random.choice(DOG_ACK_MESSAGES))
+    except Exception:
+        pass  # never let ack failure block the real work
 
 # Must match the sentinel in server.js — used to detect replies-to-den
 DEN_REPLY_FOOTER = "\n↩️ reply to this message to talk to this session directly"
@@ -229,6 +248,10 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
     history = chat_histories[chat_id]
 
     routing = {"adapter": "telegram", "chat_id": chat_id}
+
+    # Immediate ack — let the user know we heard them before Haiku starts thinking
+    await _dog_ack(update)
+
     try:
         result = get_response(user_message, conversation_history=list(history), routing=routing)
     except Exception as e:
@@ -373,6 +396,10 @@ async def handle_photo(update: Update, context: ContextTypes.DEFAULT_TYPE):
     history = chat_histories[chat_id]
 
     routing = {"adapter": "telegram", "chat_id": chat_id}
+
+    # Immediate ack — let the user know we're looking at their photo
+    await _dog_ack(update)
+
     try:
         result = get_response(user_message, conversation_history=list(history), routing=routing, user_content=user_content)
     except Exception as e:


### PR DESCRIPTION
## Summary

- Fires a short acknowledgment the moment a Telegram message lands — before Haiku starts processing
- Randomized from a pool of dog-themed acks: "🐶 on it...", "🐶 sniffing...", "🐶 heard you", "🐶 *perks ears*", "🐶 one sec..."
- Covers text messages and photos. Voice already has its own ack ("🐶 listening..."). Den replies excluded — they have their own delivery confirmation flow.

## Design decisions

**Where the ack lives:** `telegram_adapter.py` — the adapter layer, not the core. The ack is a Telegram UX concern, not a bot logic concern. Each adapter can handle acks differently.

**Delegated work vs inline:** The ack fires unconditionally before `get_response()`. Whether Haiku responds with text directly or spawns a session, the user always gets immediate feedback. For session spawns (the slow path), this bridges the gap. For quick text responses, the ack is followed almost immediately by the real answer — slightly chattier but consistent.

**Failure isolation:** `_dog_ack()` is wrapped in a bare except — if the ack fails (network blip, rate limit), the real processing continues unblocked.

Closes #69

## Test plan

- [ ] Send a text message to the bot → should see a random ack before the response
- [ ] Send a photo → should see a random ack before the response
- [ ] Send a voice message → should still see "🐶 listening..." (unchanged)
- [ ] Reply to a den notification → should NOT see an ack (den flow is unchanged)
- [ ] Verify ack messages rotate (send several messages, confirm variety)

🐶 Generated with [Claude Code](https://claude.com/claude-code)