### PR TITLE
wolf: check for updates every 5 minutes

### DIFF
--- a/template/wolt/wolf.json
+++ b/template/wolt/wolf.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "name": "update-check",
-      "schedule": "0 10 * * *",
+      "schedule": "*/5 * * * *",
       "action": "script",
       "command": "bash /workspace/woltspace/container/cron/check-update.sh",
       "timezone": "America/Montreal"


### PR DESCRIPTION
## What

Bumps the `update-check` wolf cron from daily (10am Montreal) to every 5 minutes.

## Why

`check-update.sh` is just `git ls-remote` — a single lightweight TCP handshake with GitHub. No clone, no checkout, no local git state changes. Zero app impact at any frequency.

Daily was too slow for active development. 5min means updates are surfaced promptly.

## Order of merge

Merge this one first, then #78 (update skill gate). After both land, wolf will notify within 5 minutes when #78 is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)