### PR TITLE
check-update: notify once per release, fix message wording

### DIFF
--- a/container/cron/check-update.sh
+++ b/container/cron/check-update.sh
@@ -49,11 +49,14 @@ if [ "$LOCAL_VERSION" = "$REMOTE_HEAD" ]; then
   exit 0
 fi
 
-# Update available — notify via the notify binary (handles session routing correctly)
+# Update available — notify once, then stamp the new version so we don't spam
 LOCAL_SHORT=$(echo "$LOCAL_VERSION" | cut -c1-7)
 REMOTE_SHORT=$(echo "$REMOTE_HEAD" | cut -c1-7)
 
-MESSAGE="a woltspace update is available ($LOCAL_SHORT -> $REMOTE_SHORT). to update, ask: \"can you update woltspace?\""
+MESSAGE="a woltspace update is available ($LOCAL_SHORT -> $REMOTE_SHORT). to find out what changed, ask: \"can you update woltspace?\""
 notify "$MESSAGE"
+
+# Stamp the new remote version so we only notify once per release
+echo "$REMOTE_HEAD" > "$VERSION_FILE"
 
 echo "[update-check] notified: update available ($LOCAL_SHORT -> $REMOTE_SHORT)"


### PR DESCRIPTION
## What

Two small UX fixes to `check-update.sh`.

## Changes

**Notify once per release** — after sending the notification, stamp the new remote version into `.state/woltspace-version`. Previously the file was never updated after the initial run, so wolf would spam the user every 5 minutes until they applied the update. Now it fires once per new release.

**Better message wording** — "to find out what changed, ask: can you update woltspace?" instead of "to update, ask...". The update skill reviews the diff first — the user decides whether to pull. The old wording implied it would just apply immediately.

## Expected UX after merge

One message from howlie when a new release lands:
> 🐺 howlie: a woltspace update is available (383007d -> abc1234). to find out what changed, ask: "can you update woltspace?"

Then silence until the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)