### PR TITLE
fix: never route /update to otter — beaver/raccoon only

### DIFF
--- a/container/bot/core.py
+++ b/container/bot/core.py
@@ -170,6 +170,7 @@ Sessions run as creatures: 🦝 **raccoon** (opus — complex reasoning, orchest
 CRITICAL: When the user asks for a specific creature by name, ALWAYS use that creature. Never override their choice based on your own task decomposition. "Fire up a raccoon" means creature="raccoon", period.
 
 **When to use otter vs beaver:** Otter is haiku — fast and cheap, great for quick lookups, simple edits, file searches, one-shot scripts. Beaver is sonnet — deeper reasoning, multi-file changes, architecture work. Default to beaver for ambiguous tasks; use otter when speed matters more than depth.
+**NEVER use otter for platform updates.** Any task involving `/update`, running the update skill, or pulling woltspace changes must always use **beaver** or **raccoon** — never otter. Updates require careful review and can break the running platform; haiku is not appropriate.
 
 The colony has more creatures — not all are session types yet, but they have roles:
 **dog** — that's you. Telegram companion, loyal and constrained
@@ -193,7 +194,7 @@ You have tools. Use them. Never describe what you would do — always invoke the
 CRITICAL: If a task requires claude_code, call claude_code. Don't narrate what you'd do instead.
 
 - **claude_code** — spin up a Claude Code session for real work (pick raccoon, beaver, otter, or wolf as needed)
-- **check_update** — check if a woltspace update is available. If yes, suggest the user ask a beaver or raccoon to update
+- **check_update** — check if a woltspace update is available. If yes, suggest the user ask a beaver or raccoon to update. NEVER dispatch the update itself to otter — always beaver or raccoon.
 - **wolf_schedules** — check what crons are configured and when they last ran
 - **fire_wolf** — trigger a specific cron immediately by name (check wolf_schedules first for names)
 - **wolf_jobs** — show recent wolf job log (what fired, when, success/failure)
@@ -789,7 +790,7 @@ def _tool_check_update(args: dict, routing: dict | None) -> str:
             "up_to_date": False,
             "local": local_version[:7],
             "remote": remote_head[:7],
-            "message": "an update is available — suggest the user ask a beaver or raccoon to handle it",
+            "message": "an update is available — route to beaver or raccoon to handle it. NEVER use otter for updates.",
         })
     except Exception as e:
         return json.dumps({"error": str(e)})


### PR DESCRIPTION
Closes #82

## The problem

Dog had no hard constraint against routing `/update` to otter. The existing guidance was advisory ("suggest beaver or raccoon"), but when a user directly asks to run an update, dog could reasonably pick otter — it looks like a quick, lightweight task from the outside. Haiku isn't appropriate here: updates require careful review of incoming platform changes and can break the running server, bot, and tunnel if mishandled.

## The fix

Three reinforcing constraints in `container/bot/core.py`:

1. **System prompt — routing rules section**: Added an explicit `NEVER use otter for platform updates` rule immediately after the otter/beaver guidance, with rationale (platform safety, not just a preference).

2. **Tool list description for `check_update`**: Clarified that the tool result suggesting a rodent means beaver or raccoon specifically — otter is excluded.

3. **`_tool_check_update` result message**: The JSON returned when an update is available now explicitly says "NEVER use otter."

## Why three places

The LLM reads all three contexts when making a routing decision. A single rule can be overridden by other signals; three consistent constraints pointing the same direction are much harder to override accidentally.

## Test

After rebuild, ask dog: "run /update" or "update woltspace" — should spawn a beaver or raccoon, never otter.