### PR TITLE
Fix install.sh — PATH persistence and WOLTS_DIR mismatch

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -17,7 +17,6 @@ else
   git clone https://github.com/jerpint/woltspace
 fi
 
-export PATH="$PWD/woltspace:$PATH"
-export WOLTS_DIR="${WOLTS_DIR:-$PWD}"
+export WOLTS_DIR="${WOLTS_DIR:-$HOME/wolts}"
 
-woltspace init
+"$PWD/woltspace/woltspace" init


### PR DESCRIPTION
## Summary

Two bugs in `install.sh` that broke first-run onboarding:

- **PATH never persists**: `install.sh` exported PATH before calling `woltspace init`, so init saw `woltspace` already on PATH and skipped writing to `.bashrc`/`.zshrc`. New shell → `woltspace: command not found`.
- **WOLTS_DIR mismatch**: `install.sh` defaulted to `$PWD`, but the CLI defaults to `$HOME/wolts`. Init created the wolt in one place, `woltspace start` looked in another.

## Fix

Two lines changed:
1. Call woltspace by absolute path (`"$PWD/woltspace/woltspace" init`) — lets init properly detect it's not on PATH and offer to add it to the shell rc
2. Default `WOLTS_DIR` to `$HOME/wolts` — matches the CLI default so everything stays consistent across sessions

Idempotent: re-running install.sh pulls latest, re-runs init which detects existing wolt and exits cleanly.

## Test plan

- [ ] Fresh install: `curl -fsSL https://woltspace.com/install.sh | bash` — PATH added to rc, wolt created at `~/wolts/<name>`
- [ ] New shell after install: `woltspace start` finds the wolt
- [ ] Re-run install.sh: pulls latest, init detects existing wolt, exits cleanly
- [ ] Custom WOLTS_DIR: `WOLTS_DIR=/tmp/test-wolts curl ... | bash` still works

🐾 someone's onboarding broke — fixing the dam

🤖 Generated with [Claude Code](https://claude.com/claude-code)