### PR TITLE
Fix session reconcile on boot — was silently failing

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -12,9 +12,6 @@ source "$ENV_FILE"
 rm -f "$ENV_FILE"
 export WOLT_NAME WOLT_DIR DEV_MODE WOLF_CONFIG PYTHONPATH PATH
 
-# ── Reconcile stale sessions from previous boot ──
-python3 -c "from sessions import SessionRegistry; SessionRegistry.reconcile()" 2>/dev/null || true
-
 # ── tmux ──
 tmux new-session -d -s main -c "$WOLT_DIR" 2>/dev/null || true
 if [ -f /home/node/.claude/.first-run ]; then

--- a/container/entrypoint_setup.py
+++ b/container/entrypoint_setup.py
@@ -198,6 +198,28 @@ def resolve_bot_module(wolt_dir: Path, woltspace_dir: Path, adapter: str) -> tup
     return str(woltspace_dir / "container"), f"bot.{adapter}_adapter"
 
 
+def reconcile_sessions(wolts_dir: Path, woltspace_dir: Path):
+    """Mark any 'running' sessions as orphaned if their tmux session is gone.
+
+    Runs on container boot before tmux starts, so any session still marked
+    'running' from a previous boot is definitely dead.
+    """
+    registry_dir = wolts_dir / ".state" / "registry"
+    if not registry_dir.is_dir():
+        return
+    lib_dir = str(woltspace_dir / "container" / "lib")
+    if lib_dir not in sys.path:
+        sys.path.insert(0, lib_dir)
+    try:
+        from sessions import SessionRegistry
+        reg = SessionRegistry(registry_dir)
+        orphaned = reg.reconcile()
+        if orphaned:
+            print(f"reconciled {len(orphaned)} orphaned session(s): {', '.join(orphaned)}")
+    except Exception as e:
+        print(f"session reconcile skipped: {e}", file=sys.stderr)
+
+
 def symlink_node_modules(woltspace_dir: Path):
     target = Path("/workspace/node_modules")
     if target.is_symlink() or target.exists():
@@ -237,6 +259,9 @@ def main():
     configure_git(wolt_name)
     seed_wolf_json(wolt_dir, woltspace_dir)
     symlink_node_modules(woltspace_dir)
+
+    # Clean up stale sessions from previous boot
+    reconcile_sessions(wolts_dir, woltspace_dir)
 
     # Resolve derived values for bash
     wolf_config = resolve_wolf_config(wolts_dir, wolt_dir)


### PR DESCRIPTION
## Summary

the reconcile call in entrypoint.sh was calling `SessionRegistry.reconcile()` as a class method — but it's an instance method. the `2>/dev/null || true` swallowed the TypeError every boot, so stale "running" sessions were never cleaned up after a kill or crash.

- moved reconcile into `entrypoint_setup.py` where it properly instantiates `SessionRegistry(registry_dir)` 
- runs before tmux launches, so every leftover "running" entry gets marked orphaned
- errors go to stderr instead of being silently swallowed
- removed the broken bash one-liner from `entrypoint.sh`

## edge cases covered

- first boot (no registry dir yet) — early return
- no tmux running — correct behavior, all "running" entries are stale
- PYTHONPATH not set yet — manually adds container/lib to sys.path  
- corrupt JSON in registry — handled by sessions.py's existing try/except
- import failure — caught and logged, doesn't block boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)