### PR TITLE
Update /update skill for new architecture + drift detection

### DIFF
--- a/MIGRATE.md
+++ b/MIGRATE.md
@@ -15,7 +15,7 @@
 | Internal port | `3000` | `7777` | Container-internal references break |
 | Tunnel env var | `ENABLE_TUNNEL` | `WOLTSPACE_PUBLIC_TUNNEL` | **SECURITY** — disabled tunnel may re-enable |
 | Dev mode flag | `--dev` | `--local` / `--branch` | Workflow change |
-| Woltspace in container | Mounted from host (`-v`) | Baked into image (git clone) | `/update` skill stops working |
+| Woltspace in container | Mounted from host (`-v`) | Git clone inside image | `/update` still works; image goes stale until rebuild |
 
 ---
 
@@ -496,12 +496,12 @@ ENABLE_TUNNEL=false            → WOLTSPACE_PUBLIC_TUNNEL=false
 woltspace start --dev          → woltspace start --local
 woltspace rebuild --dev        → woltspace rebuild --local
 woltspace restart              → woltspace stop && woltspace start
-/update (inside container)     → git pull && woltspace rebuild (on host)
+/update (inside container)     → still works (git pull inside clone)
 ```
 
 ## Known limitations after migration
 
-1. **`/update` skill doesn't work** — platform code is baked into the image. Update from host: `git pull && woltspace rebuild`.
-2. **No live-reload of platform code** — changes require `woltspace rebuild --local`. Wolts can no longer accidentally modify platform code.
-3. **Dev mode changed** — `--local` builds from local repo into the image (COPY, not mount). More rebuilds, better isolation.
+1. **Image goes stale after in-app updates** — `/update` still works (the container has a git clone), but after pulling, the Docker image is stale vs the running container. Run `woltspace rebuild` from the host to re-bake the image for future cold starts (not required for the current session).
+2. **No live-mount of platform code** — on `main`, woltspace was mounted from the host so edits were instant. Now it's a clone inside the container. For iterative platform development, use `--local` builds.
+3. **Dev mode changed** — `--local` builds from your local repo into the image (COPY, not mount). More rebuilds, better isolation.
 4. **Deploy key mount removed** — use `GH_PAT_TOKEN` in `.env` instead of SSH deploy keys.

--- a/container/skills/update/SKILL.md
+++ b/container/skills/update/SKILL.md
@@ -8,15 +8,57 @@ user_invocable: true
 
 You are the lodge's gatekeeper for platform updates. Your job: check what's arriving from upstream, translate it into plain language (no git jargon), flag anything that could disrupt the lodge, and only open the gates when the human says go.
 
-**Never pull without explicit user confirmation. This is the safety gate — updates can crash the app.**
+**Never pull without explicit user confirmation. This is the safety gate — updates can crash the running app.**
 
-`/workspace/woltspace` is volume-mounted from the host, so `git pull` updates files live — no rebuild needed in most cases.
+## Step 0: Check for local drift
+
+Before anything else, check if the platform code has been modified inside the container. Wolts or Claude sessions sometimes accidentally edit files in `/workspace/woltspace`. If there's drift, a pull will fail with merge conflicts.
+
+```bash
+cd /workspace/woltspace
+DRIFT=$(git status --short)
+```
+
+**If drift is found:**
+
+1. Show the user what's changed:
+```bash
+git status --short
+git diff --stat
+```
+
+2. Categorize the risk:
+   - `container/entrypoint.sh`, `server.js`, `server/`, `woltspace` → **HIGH** — platform infrastructure
+   - `container/bot/`, `container/creatures/` → **MEDIUM** — bot/creature code
+   - `container/skills/`, `CLAUDE.md`, `*.md` → **LOW** — skills/docs, likely auto-updated
+
+3. Notify the user about the drift and ask how to proceed:
+   - **If LOW risk only:** "found some skill/doc changes in the platform dir — safe to discard. want me to reset and pull?"
+   - **If MEDIUM/HIGH risk:** "found modifications to platform code — [list files]. these will be lost on pull. want me to save them to a branch first, or discard and proceed?"
+
+4. If the user wants to save:
+```bash
+cd /workspace/woltspace
+git checkout -b backup/pre-update-$(date +%Y%m%d-%H%M%S)
+git add -A
+git commit -m "pre-update snapshot — local modifications"
+git checkout -  # return to previous branch
+```
+
+5. Reset to clean state before proceeding:
+```bash
+cd /workspace/woltspace
+git checkout -- .
+git clean -fd
+```
+
+**If clean (no drift):** proceed to Step 1.
 
 ## Step 1: Determine what's incoming
 
 ```bash
 WOLT_DIR="${WOLT_DIR:-/workspace/wolts/${WOLT_NAME:-wolt}}"
-BRANCH=$(cat "$WOLT_DIR/.state/woltspace-branch" 2>/dev/null || echo "staging")
+BRANCH=$(cat "$WOLT_DIR/.state/woltspace-branch" 2>/dev/null || echo "main")
 
 cd /workspace/woltspace
 git fetch origin "$BRANCH"
@@ -29,6 +71,12 @@ REMOTE=$(git rev-parse "origin/$BRANCH")
 ```
 
 If they match, tell the user they're already up to date and stop.
+
+Also show the current version:
+```bash
+echo "Current: $(cat /workspace/woltspace/.version 2>/dev/null || git rev-parse --short HEAD)"
+echo "Latest:  $(git rev-parse --short origin/$BRANCH)"
+```
 
 ## Step 2: Review the changes
 
@@ -43,8 +91,7 @@ Read the actual diff for anything that looks like it could break existing behavi
 - **Config/env changes** — new required env vars, renamed vars, changed defaults
 - **Removed or renamed files** — skills, cron scripts, bot tools that wolts might depend on
 - **CLAUDE.md changes** — new instructions that change how sessions behave
-- **entrypoint.sh changes** — startup behavior, process management
-- **woltspace CLI changes** — flag changes, new required args
+- **entrypoint.sh / entrypoint_setup.py changes** — startup behavior, process management
 - **Database/state format changes** — .state files, woltspace.json schema changes
 - **Bot behavior changes** — tool renames, removed capabilities, changed routing
 
@@ -95,15 +142,17 @@ git log --oneline ORIG_HEAD..HEAD
 Notify the user: what landed, the short hash, and any action items.
 
 Action items to flag:
-- **Bot code changed** → "the bot needs a restart to pick this up — run `woltspace restart` from host"
-- **entrypoint.sh changed** → "container restart needed for this to take full effect"
-- **New env vars** → "add `VAR_NAME` to `~/wolts/.env` before restarting"
-- **server.js changed** → "server auto-reloads via --watch, should be live already"
+- **Bot code changed** → "the bot needs a restart to pick this up — a container restart is needed"
+- **entrypoint.sh or entrypoint_setup.py changed** → "container restart needed for this to take full effect"
+- **New env vars** → "add `VAR_NAME` to your `.env` before restarting"
+- **Server code changed** → "server auto-reloads via uvicorn --reload, should be live already"
+- **Skills changed** → "skills update on next session start — existing sessions keep the old version"
 
 ## Notes
 
-- `woltspace rebuild` is a **host-only** command — no docker CLI inside the container
-- `server.js` runs with `--watch` so JS changes auto-apply without restart
-- The Telegram bot does NOT auto-restart — if bot code changed, flag it explicitly
+- The platform code at `/workspace/woltspace` is a git clone inside the container — `git pull` works
+- After pulling, the running image is now stale vs the container's filesystem. A `woltspace rebuild` from the host will re-bake the image for future cold starts, but isn't required for the current session
+- The Telegram/Slack bots do NOT auto-restart — if bot code changed, flag it explicitly
+- The uvicorn server runs with `--reload` so Python server changes auto-apply
 - When in doubt about whether a change is breaking, err on the side of flagging it
 - If the user invokes `/update confirm` or already said "yes, pull it", skip straight to Step 4


### PR DESCRIPTION
## the gatekeeper learns new terrain

the /update skill was built for a world where woltspace was mounted live from the host. the clone-based architecture changes the ground under its feet — not broken, but it needs to know the new rules.

**new step 0: drift detection.** before fetching anything, the gatekeeper now checks if wolts have been gnawing on platform code inside the container. categorizes changes by risk (HIGH for infra, MEDIUM for bot code, LOW for skills/docs). offers to save modifications to a branch before discarding. no more silent merge conflicts.

**corrected: /update still works.** the container has a full git clone, so git pull works fine. the image just goes stale until the next `woltspace rebuild` from the host — but the running session picks up changes immediately.

also: updated MIGRATE.md to reflect this — removed the incorrect "/update doesn't work" limitation.

### changes

- `/update` skill: added drift check (Step 0), risk categorization, branch-saving flow, updated defaults and notes
- `MIGRATE.md`: corrected /update limitation, updated summary table

🤖 Generated with [Claude Code](https://claude.com/claude-code)