### PR TITLE
Swap voice ack emoji: the bat awakens

### DIFF
--- a/container/bot/telegram_adapter.py
+++ b/container/bot/telegram_adapter.py
@@ -286,7 +286,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     chat_id = update.effective_chat.id
 
-    await update.message.reply_text("🐶 listening...")
+    await update.message.reply_text("🦇 listening...")
 
     file = await context.bot.get_file(voice.file_id)
     with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as tmp:


### PR DESCRIPTION
The lodge's voice listener traded its dog ears for bat sonar. When a voice message arrives, the acknowledgment now echoes back with 🦇 instead of 🐶 — because bats are the ones who truly *listen* in the dark.

One-line change in `telegram_adapter.py`, line 289.

Closes #72