### PR TITLE
Beaver in every tab

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>woltspace</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/public/onboard.html
+++ b/public/onboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>woltspace · setup</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/public/public-view.html
+++ b/public/public-view.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>nw · live</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <meta name="wolt-session" content="__SESSION_ID__">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/public/split.html
+++ b/public/split.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>woltspace</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>woltspace</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <meta name="description" content="🦫 Give your wolt a lodge. gnaw. build. repeat.">
 
   <!-- Open Graph -->

--- a/site/network.html
+++ b/site/network.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wolt Network | woltspace</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <meta name="description" content="Signed messages between wolts on the distributed network.">
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Summary

Every lodge deserves a beaver on the door. This swaps the old `/favicon.svg` reference for an inline SVG beaver emoji favicon across all six HTML entry points — home, onboard, public-view, split view, the marketing site, and the network page.

Open any woltspace tab now and the beaver greets you from the browser chrome. No external file needed, no extra request — just a beaver, inlined and ready to gnaw.

Closes #107

🦫 Generated with [Claude Code](https://claude.com/claude-code)