### PR TITLE
Playful dog acks — tail wags, head tilts, tippy taps

### DIFF
--- a/container/bot/telegram_adapter.py
+++ b/container/bot/telegram_adapter.py
@@ -42,11 +42,23 @@ MAX_HISTORY = 20
 
 # Immediate ack messages — sent before processing starts so the user knows we heard them
 DOG_ACK_MESSAGES = [
-    "🐶 on it...",
-    "🐶 sniffing...",
-    "🐶 heard you",
+    "🐶 *tail wags vigorously*",
     "🐶 *perks ears*",
-    "🐶 one sec...",
+    "🐶 woof woof",
+    "🐶 ...",
+    "🐶 *sniffs curiously*",
+    "🐶 *head tilt*",
+    "🐶 *tippy taps*",
+    "🐶 *play bows*",
+    "🐶 *ears forward*",
+    "🐶 *full body wiggle*",
+]
+
+DOG_VOICE_ACKS = [
+    "🐶 *ear perks up*",
+    "🐶 *listens intently*",
+    "🐶 *head tilt*",
+    "🐶 ...",
 ]
 
 
@@ -286,7 +298,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
 
     chat_id = update.effective_chat.id
 
-    await update.message.reply_text("🐶 listening...")
+    await update.message.reply_text(random.choice(DOG_VOICE_ACKS))
 
     file = await context.bot.get_file(voice.file_id)
     with tempfile.NamedTemporaryFile(suffix=".ogg", delete=False) as tmp:


### PR DESCRIPTION
## Summary

The dog learns new tricks. Fuji's acks go from generic ("on it...", "sniffing...") to genuine dog behaviors — tail wags, play bows, tippy taps, full body wiggles.

Voice messages get their own pool of listening-specific acks (ear perks, intent listening, head tilts) instead of the hardcoded "listening..." string.

All acks keep the 🐶 prefix for consistency.

## The new repertoire

**Text/photo acks:** tail wags vigorously, perks ears, woof woof, sniffs curiously, head tilt, tippy taps, play bows, ears forward, full body wiggle

**Voice acks:** ear perks up, listens intently, head tilt

## Test plan

- [ ] Send a text message → get a random playful ack
- [ ] Send a voice message → get a random listening ack
- [ ] Send a photo → get a random playful ack
- [ ] All acks have 🐶 prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)