### PR TITLE
Release system — versioning, changelog, version-aware /update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## v0.0.2 (unreleased)
+
+- Playful dog acks — tail wags, head tilts, tippy taps instead of generic "on it..." (#112)
+- Beaver favicon across all HTML pages (#111)
+- Wolf catch-up logic — fire missed crons on startup after container restart (#109)
+
+## v0.0.1 (2026-03-16)
+
+First versioned release. Architecture refactor: git clone in Dockerfile, single mount, port 7777, simplified CLI, backup system, smoke tests. See PR #104.

--- a/VERSIONING.md
+++ b/VERSIONING.md
@@ -1,0 +1,45 @@
+# Versioning
+
+Woltspace follows semantic versioning: **vMAJOR.MINOR.PATCH**
+
+## Version digits
+
+### PATCH (v0.0.X) — safe updates
+Non-breaking changes. New features, bug fixes, UI tweaks, new creature behaviors. `/update` pulls these with a quick sanity check. No migration needed.
+
+Examples: new dog acks, favicon change, wolf catch-up logic, skill improvements.
+
+### MINOR (v0.X.0) — breaking changes, migration required
+Changes that require user action. New env vars, renamed files, changed config formats, removed features. `/update` detects these and walks the user through the migration before pulling.
+
+Each minor bump ships a migration script in `migrations/vX.Y.0.sh` that automates what it can and flags what needs manual attention.
+
+Examples: config schema change, new required env var, creature API change, state format migration.
+
+### MAJOR (vX.0.0) — platform overhaul
+Rare. Fundamental architecture changes. Reserved for when the platform shape changes significantly.
+
+Examples: new container architecture, complete rewrite of session system, breaking API changes across all creatures.
+
+## Files
+
+- `.version` — current version string (e.g. `v0.0.2`), stamped on release and by `/update`
+- `CHANGELOG.md` — human-readable change log per version
+- `migrations/` — migration scripts for minor/major bumps
+
+## Release workflow
+
+1. Merge PRs to main
+2. When ready to cut a release:
+   - Update `.version`
+   - Update `CHANGELOG.md`
+   - If minor/major: add migration script to `migrations/`
+   - Tag: `git tag vX.Y.Z && git push origin vX.Y.Z`
+   - Create GitHub release from the tag
+3. Users run `/update` to pull the new version
+
+## How /update uses versions
+
+- Reads current `.version` from the running container
+- Fetches latest tag from origin
+- Compares: patch bump → safe pull with sanity check. Minor/major bump → flag it, show migration notes, require explicit confirmation.

--- a/container/skills/update/SKILL.md
+++ b/container/skills/update/SKILL.md
@@ -61,7 +61,7 @@ WOLT_DIR="${WOLT_DIR:-/workspace/wolts/${WOLT_NAME:-wolt}}"
 BRANCH=$(cat "$WOLT_DIR/.state/woltspace-branch" 2>/dev/null || echo "main")
 
 cd /workspace/woltspace
-git fetch origin "$BRANCH"
+git fetch origin "$BRANCH" --tags
 ```
 
 Check if there's actually anything new:
@@ -72,16 +72,46 @@ REMOTE=$(git rev-parse "origin/$BRANCH")
 
 If they match, tell the user they're already up to date and stop.
 
-Also show the current version and latest available:
+## Step 2: Determine the version bump type
+
 ```bash
-CURRENT=$(cat /workspace/woltspace/.version 2>/dev/null || git rev-parse --short HEAD)
+CURRENT=$(cat /workspace/woltspace/.version 2>/dev/null || echo "v0.0.0")
 LATEST_TAG=$(git describe --tags --abbrev=0 origin/$BRANCH 2>/dev/null || echo "untagged")
-LATEST_HASH=$(git rev-parse --short origin/$BRANCH)
-echo "Current: $CURRENT"
-echo "Latest:  ${LATEST_TAG} (${LATEST_HASH})"
 ```
 
-## Step 2: Review the changes
+Parse the version components to determine the bump type:
+
+```bash
+# Parse current version (strip leading 'v')
+CUR="${CURRENT#v}"
+CUR_MAJOR=$(echo "$CUR" | cut -d. -f1)
+CUR_MINOR=$(echo "$CUR" | cut -d. -f2)
+CUR_PATCH=$(echo "$CUR" | cut -d. -f3)
+
+# Parse latest tag
+LAT="${LATEST_TAG#v}"
+LAT_MAJOR=$(echo "$LAT" | cut -d. -f1)
+LAT_MINOR=$(echo "$LAT" | cut -d. -f2)
+LAT_PATCH=$(echo "$LAT" | cut -d. -f3)
+
+# Determine bump type
+if [ "$LAT_MAJOR" != "$CUR_MAJOR" ]; then
+  BUMP="major"
+elif [ "$LAT_MINOR" != "$CUR_MINOR" ]; then
+  BUMP="minor"
+else
+  BUMP="patch"
+fi
+echo "Bump type: $BUMP ($CURRENT → $LATEST_TAG)"
+```
+
+Also check if a migration script exists for the target version:
+```bash
+MIGRATION="/workspace/woltspace/migrations/${LATEST_TAG}.sh"
+# We'll check after pulling — the migration ships with the new code
+```
+
+## Step 3: Review the changes
 
 Look at what's incoming:
 ```bash
@@ -89,8 +119,12 @@ git log --oneline HEAD..origin/$BRANCH
 git diff --stat HEAD..origin/$BRANCH
 ```
 
-Read the actual diff for anything that looks like it could break existing behavior. Focus on:
+Read the actual diff for anything that looks like it could break existing behavior. Also read the CHANGELOG.md from the incoming code if it exists:
+```bash
+git show origin/$BRANCH:CHANGELOG.md 2>/dev/null || echo "no changelog"
+```
 
+Focus on:
 - **Config/env changes** — new required env vars, renamed vars, changed defaults
 - **Removed or renamed files** — skills, cron scripts, bot tools that wolts might depend on
 - **CLAUDE.md changes** — new instructions that change how sessions behave
@@ -98,19 +132,21 @@ Read the actual diff for anything that looks like it could break existing behavi
 - **Database/state format changes** — .state files, woltspace.json schema changes
 - **Bot behavior changes** — tool renames, removed capabilities, changed routing
 
-If a merge PR exists for the incoming commits, read it for context. Check if there's a changelog or migration notes.
+## Step 4: Report to the user
 
-## Step 3: Report to the user
+**Tone: lore-flavored, brief by default.** Lead with what's cool and new. Only go technical if the user asks or if something could break.
 
-**Tone: lore-flavored, brief by default.** Lead with what's cool and new — speak like you're reporting back to the lodge, not filing a ticket. Only go technical if the user asks, or if something could break.
+### Patch bump (safe)
+> 🟢 **Patch update available** ($CURRENT → $LATEST_TAG)
+> [1-2 sentence lore-flavored summary]. Safe to pull — no migration needed. Want me to bring it in?
 
-Send a notify with your assessment. Structure it as:
+### Minor bump (migration required)
+> 🟡 **Minor update available** ($CURRENT → $LATEST_TAG) — migration required
+> [summary of what's new]. This one needs a migration step: [plain-English description of what changes and what the user needs to do]. Want details, or proceed?
 
-**If safe (no breaking changes):**
-> [1-2 sentence lore-flavored summary of what's new — e.g. "the wolf learned to read the stars" or "dog now barks before thinking"]. Good to pull — no side effects. Want me to bring it in?
-
-**If there are concerns:**
-> [lore summary of what's new]. One thing to know first: [plain-English description of the specific risk — e.g. "needs a new OPENAI_API_KEY in .env" or "wolf skill was renamed, existing schedules may need a look"]. Want details, or proceed?
+### Major bump (platform overhaul)
+> 🔴 **Major update available** ($CURRENT → $LATEST_TAG) — significant changes
+> [summary]. This is a big one: [description of what's changing]. I'd recommend reading the full changelog before pulling. Want me to walk through it?
 
 Rules:
 - Lead with the cool stuff, not the risk
@@ -118,9 +154,9 @@ Rules:
 - Never say "breaking changes" without saying exactly what breaks and what the user needs to do
 - Offer "want more details?" rather than front-loading everything
 
-## Step 4: Confirm before pulling
+## Step 5: Confirm before pulling
 
-**Use `AskUserQuestion` to wait for the user's explicit yes/no.** Do not skip this. Do not assume consent. A raw "what's new?" message is not a pull request.
+**Use `AskUserQuestion` to wait for the user's explicit yes/no.** Do not skip this. Do not assume consent.
 
 Accept any of: "yes", "pull it", "go ahead", "do it", "yes pull", "/update confirm".
 
@@ -138,16 +174,35 @@ echo "$BRANCH" > "$WOLT_DIR/.state/woltspace-branch"
 echo "$NEW_VERSION" > /workspace/woltspace/.version
 ```
 
-## Step 5: Verify and report
+## Step 6: Run migration (minor/major bumps only)
+
+After pulling, check for a migration script:
+
+```bash
+MIGRATION="/workspace/woltspace/migrations/${NEW_VERSION}.sh"
+if [ -f "$MIGRATION" ]; then
+  echo "Migration script found: $MIGRATION"
+  cat "$MIGRATION"
+fi
+```
+
+**For patch bumps:** skip migration entirely — just do a quick sanity check:
+- Did the pull succeed cleanly?
+- Are the key processes still running? (`curl -s http://localhost:7777/health` or similar)
+- Report success.
+
+**For minor/major bumps:** if a migration script exists, show it to the user and run it with their confirmation. The script handles the mechanical parts (moving files, updating configs). Flag anything that needs manual action (new env vars, etc.).
+
+## Step 7: Verify and report
 
 ```bash
 git log --oneline ORIG_HEAD..HEAD
 ```
 
-Notify the user: what landed, the short hash, and any action items.
+Notify the user: what landed, the version, and any action items.
 
 Action items to flag:
-- **Bot code changed** → "the bot needs a restart to pick this up — a container restart is needed"
+- **Bot code changed** → "the bot auto-reloads via watchfiles — should pick this up shortly"
 - **entrypoint.sh or entrypoint_setup.py changed** → "container restart needed for this to take full effect"
 - **New env vars** → "add `VAR_NAME` to your `.env` before restarting"
 - **Server code changed** → "server auto-reloads via uvicorn --reload, should be live already"
@@ -157,7 +212,7 @@ Action items to flag:
 
 - The platform code at `/workspace/woltspace` is a git clone inside the container — `git pull` works
 - After pulling, the running image is now stale vs the container's filesystem. A `woltspace rebuild` from the host will re-bake the image for future cold starts, but isn't required for the current session
-- The Telegram/Slack bots do NOT auto-restart — if bot code changed, flag it explicitly
 - The uvicorn server runs with `--reload` so Python server changes auto-apply
+- Bot code auto-reloads via watchfiles
 - When in doubt about whether a change is breaking, err on the side of flagging it
-- If the user invokes `/update confirm` or already said "yes, pull it", skip straight to Step 4
+- If the user invokes `/update confirm` or already said "yes, pull it", skip straight to Step 5

--- a/migrations/README.md
+++ b/migrations/README.md
@@ -1,0 +1,21 @@
+# Migrations
+
+Migration scripts for minor and major version bumps. Patch bumps don't need migrations.
+
+## Naming
+
+- `v0.1.0.sh` — migration for the v0.1.0 release
+- `v0.2.0.sh` — migration for the v0.2.0 release
+- `v1.0.0.sh` — migration for the v1.0.0 release
+
+## Structure
+
+Each migration script should:
+1. Check preconditions (current version, required files)
+2. Automate what it can (move files, update configs)
+3. Print clear instructions for anything that needs manual action
+4. Be idempotent — safe to run twice
+
+## Usage
+
+The `/update` skill runs the appropriate migration automatically when it detects a minor or major bump.


### PR DESCRIPTION
## Summary

The lodge gets a proper release cadence. Three digits, three levels of trust.

**PATCH** (v0.0.X) — safe stuff. Dog acks, favicon swaps, wolf improvements. /update pulls with a quick sanity check and a green light.

**MINOR** (v0.X.0) — breaking changes that need a migration script. New env vars, renamed configs, state format changes. /update detects these, shows the migration, walks you through it.

**MAJOR** (vX.0.0) — platform overhaul. Rare. /update flags it red and recommends reading the full changelog first.

### What's new

- `VERSIONING.md` — documents the scheme
- `CHANGELOG.md` — tracks changes per version (starts with v0.0.1 + unreleased)
- `migrations/` directory — where minor/major migration scripts live
- `/update` skill rewritten to detect bump type and adjust behavior accordingly

### How /update changes

The skill now fetches tags, parses version numbers, and determines the bump type before reporting. Patch bumps get a casual green light. Minor bumps get a yellow flag with migration details. Major bumps get a red flag with a full walkthrough recommendation.

## Test plan

- [ ] /update with no new version → "already up to date"
- [ ] /update with patch bump → green light, quick sanity check after pull
- [ ] /update with minor bump → yellow flag, migration script shown
- [ ] CHANGELOG.md readable and accurate
- [ ] VERSIONING.md clear on the rules

Related to #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)