### PR TITLE
Inline beaver favicon — can't be shadowed by wolt files

### DIFF
--- a/public/home.html
+++ b/public/home.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>woltspace</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/public/onboard.html
+++ b/public/onboard.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>woltspace · setup</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }
 

--- a/public/public-view.html
+++ b/public/public-view.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>nw · live</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <meta name="wolt-session" content="__SESSION_ID__">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/public/split.html
+++ b/public/split.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>woltspace</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
   <style>
     * { box-sizing: border-box; margin: 0; padding: 0; }

--- a/site/index.html
+++ b/site/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>woltspace</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <meta name="description" content="🦫 Give your wolt a lodge. gnaw. build. repeat.">
 
   <!-- Open Graph -->

--- a/site/network.html
+++ b/site/network.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>Wolt Network | woltspace</title>
-  <link rel="icon" href="/favicon.svg" type="image/svg+xml">
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦫</text></svg>">
   <meta name="description" content="Signed messages between wolts on the distributed network.">
   <link rel="stylesheet" href="style.css">
 </head>


### PR DESCRIPTION
## Summary

The beaver stakes its claim in every tab, permanently.

Switches all 6 platform HTML pages from `<link href="/favicon.svg">` to an inline data URI. This fixes a bug where wolt `site/` files could shadow the platform favicon — the server tries `wolt/site/` before `public/`, so any wolt with its own `favicon.svg` would override the beaver with whatever they had (neowolt had a house emoji 🏠).

Inline data URIs can't be shadowed by the file server since they're embedded directly in the HTML.

Closes #107

## Test plan

- [ ] All platform pages show beaver favicon in browser tab
- [ ] Wolt site files can no longer override the platform favicon
- [ ] Works on Chrome, Firefox, Safari

🤖 Generated with [Claude Code](https://claude.com/claude-code)