### PR TITLE
Install script pulls latest release tag, not branch tip

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -67,9 +67,20 @@ ARG USE_LOCAL=false
 ARG WOLTSPACE_BRANCH=main
 
 # Clone from github (default path)
+# Clones the branch, then checks out the latest semver tag if available.
+# Falls back to branch tip if no tags exist (safe for fresh repos).
 RUN if [ "$USE_LOCAL" = "false" ]; then \
-      git clone --branch ${WOLTSPACE_BRANCH} --single-branch --depth 1 \
-        https://github.com/jerpint/woltspace.git /workspace/woltspace; \
+      git clone --branch ${WOLTSPACE_BRANCH} --single-branch \
+        https://github.com/jerpint/woltspace.git /workspace/woltspace && \
+      cd /workspace/woltspace && \
+      git fetch --tags && \
+      LATEST_TAG=$(git tag --sort=-v:refname | head -1) && \
+      if [ -n "$LATEST_TAG" ]; then \
+        echo "checking out release: $LATEST_TAG" && \
+        git checkout "$LATEST_TAG"; \
+      else \
+        echo "no tags found — using branch tip"; \
+      fi; \
     fi
 
 # Copy local source (only meaningful when --local)

--- a/container/cron/check-update.sh
+++ b/container/cron/check-update.sh
@@ -21,15 +21,17 @@ if [ -f "$BRANCH_FILE" ]; then
   BUILD_BRANCH=$(cat "$BRANCH_FILE")
 fi
 
-# Get remote HEAD for the branch we're tracking (no clone needed)
-REMOTE_HEAD=$(git ls-remote "$WOLTSPACE_REPO" "refs/heads/$BUILD_BRANCH" 2>/dev/null | cut -f1)
+# Get the latest tag from the remote (semver-sorted)
+REMOTE_TAGS=$(git ls-remote --tags "$WOLTSPACE_REPO" 2>/dev/null | grep -v '\^{}' | awk '{print $2}' | sed 's|refs/tags/||' | sort -V)
 
-if [ -z "$REMOTE_HEAD" ]; then
-  echo "[update-check] could not reach remote"
+if [ -z "$REMOTE_TAGS" ]; then
+  echo "[update-check] no tags found on remote — nothing to compare"
   exit 0
 fi
 
-# Read stored version
+LATEST_TAG=$(echo "$REMOTE_TAGS" | tail -1)
+
+# Read stored version (could be a tag like "v0.1.0" or a commit hash from older installs)
 LOCAL_VERSION=""
 if [ -f "$VERSION_FILE" ]; then
   LOCAL_VERSION=$(cat "$VERSION_FILE")
@@ -38,25 +40,22 @@ fi
 # First run — store current version, don't notify
 if [ -z "$LOCAL_VERSION" ]; then
   mkdir -p "$STATE_DIR"
-  echo "$REMOTE_HEAD" > "$VERSION_FILE"
-  echo "[update-check] initialized version tracking ($(echo "$REMOTE_HEAD" | cut -c1-7))"
+  echo "$LATEST_TAG" > "$VERSION_FILE"
+  echo "[update-check] initialized version tracking ($LATEST_TAG)"
   exit 0
 fi
 
 # Compare
-if [ "$LOCAL_VERSION" = "$REMOTE_HEAD" ]; then
-  echo "[update-check] up to date ($(echo "$REMOTE_HEAD" | cut -c1-7))"
+if [ "$LOCAL_VERSION" = "$LATEST_TAG" ]; then
+  echo "[update-check] up to date ($LATEST_TAG)"
   exit 0
 fi
 
 # Update available — notify once, then stamp the new version so we don't spam
-LOCAL_SHORT=$(echo "$LOCAL_VERSION" | cut -c1-7)
-REMOTE_SHORT=$(echo "$REMOTE_HEAD" | cut -c1-7)
-
-MESSAGE="a woltspace update is available ($LOCAL_SHORT -> $REMOTE_SHORT). to find out what changed, ask: \"can you update woltspace?\""
+MESSAGE="a woltspace update is available ($LOCAL_VERSION -> $LATEST_TAG). to find out what changed, ask: \"can you update woltspace?\""
 notify "$MESSAGE"
 
-# Stamp the new remote version so we only notify once per release
-echo "$REMOTE_HEAD" > "$VERSION_FILE"
+# Stamp the new remote tag so we only notify once per release
+echo "$LATEST_TAG" > "$VERSION_FILE"
 
-echo "[update-check] notified: update available ($LOCAL_SHORT -> $REMOTE_SHORT)"
+echo "[update-check] notified: update available ($LOCAL_VERSION -> $LATEST_TAG)"

--- a/woltspace
+++ b/woltspace
@@ -76,7 +76,7 @@ _build_image() {
       --build-arg USE_LOCAL=true \
       -f "$WOLTSPACE_DIR/container/Dockerfile" "$WOLTSPACE_DIR"
   else
-    echo "  ${_D}🪵 building image (branch: $BUILD_BRANCH)${_R}"
+    echo "  ${_D}🪵 building image (branch: $BUILD_BRANCH, latest release tag)${_R}"
     echo "  ${_L}   felling fresh timber...${_R}"
     echo ""
     docker build -t woltspace \


### PR DESCRIPTION
## Summary

- **Dockerfile**: after cloning the branch, fetches tags and checks out the latest semver tag. Falls back to branch tip if no tags exist (safe for fresh repos).
- **check-update.sh**: compares against remote tags instead of branch HEAD — notifications now fire on new releases, not every commit to main.
- **woltspace CLI**: build log shows "latest release tag" so the user knows what's happening.

Closes #154

🤖 Generated with [Claude Code](https://claude.com/claude-code)