### PR TITLE
fix: backup survives broken symlinks

### DIFF
--- a/woltspace
+++ b/woltspace
@@ -372,7 +372,7 @@ case "$cmd" in
 
     # Wolts backup
     echo "  ${_D}copying wolts...${_R}"
-    cp -r "$WOLTS_DIR" "$BACKUP_DIR"
+    rsync -a "$WOLTS_DIR/" "$BACKUP_DIR/"
     echo "  ${_G}✓${_R} wolts → $BACKUP_DIR"
 
     # Bundle into single zip
@@ -388,7 +388,7 @@ case "$cmd" in
         docker save "woltspace-backup:$TAG" > "$TMPDIR/image.tar"
       fi
       # Copy wolts into bundle staging dir
-      cp -r "$BACKUP_DIR" "$TMPDIR/wolts"
+      rsync -a "$BACKUP_DIR/" "$TMPDIR/wolts/"
       # Write restore script
       echo "$TAG" > "$TMPDIR/.tag"
       cat > "$TMPDIR/restore.sh" << 'RESTORE'


### PR DESCRIPTION
## Summary

The backup was choking on broken symlinks — Python venvs created inside the container leave dangling links on the host mount (pointing to `/usr/bin/python3.11` which doesn't exist on macOS). Under `set -e`, `cp -r` would die on these and the bundle step never ran.

- Swap `cp -r` → `rsync -a` for both the wolts copy and the bundle staging copy
- `rsync` skips broken symlinks silently — no more aborted backups

## Test plan

- [ ] `woltspace backup` completes without errors even with broken venv symlinks
- [ ] `woltspace backup --bundle` produces the zip file
- [ ] Restore from bundle works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)