### PR TITLE
fix: ensure /home/node/.claude is writable on all platforms

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -51,7 +51,7 @@ RUN mkdir -p /workspace/wolts /home/node/.ssh \
 USER node
 
 # Copy everything the Claude installer created (binary, launcher, shell integration)
-COPY --from=claude /home/node/ /home/node/
+COPY --chown=node:node --from=claude /home/node/ /home/node/
 ENV PATH="/home/node/.local/bin:${PATH}"
 
 # Install worktui (worktree + Claude session manager)

--- a/test/test-cli.sh
+++ b/test/test-cli.sh
@@ -3,9 +3,10 @@
 # Runs a full cycle: init → start → stop → rebuild → start → stop
 #
 # Usage:
-#   bash test/test-cli.sh              # test main branch (what users get)
-#   bash test/test-cli.sh --local      # test local code
-#   bash test/test-cli.sh --branch X   # test a specific branch
+#   bash test/test-cli.sh                    # test main branch (what users get)
+#   bash test/test-cli.sh --local              # test local code
+#   bash test/test-cli.sh --branch X           # test a specific branch
+#   bash test/test-cli.sh --local --no-cache   # clean build (simulates new user, slower)
 #
 # Uses a temp WOLTS_DIR so your real wolts are untouched.
 
@@ -199,6 +200,13 @@ echo "  --- shell ---"
 step "checking shell access..."
 WHOAMI=$(docker exec "$CONTAINER_NAME" whoami 2>/dev/null || echo "")
 [ "$WHOAMI" = "node" ] && pass "shell access works (user: node)" || fail "shell access failed ($WHOAMI)"
+
+# ── permissions ──
+echo ""
+echo "  --- permissions ---"
+step "checking /home/node/.claude is writable by node..."
+docker exec "$CONTAINER_NAME" touch /home/node/.claude/.test-write 2>/dev/null && pass "/home/node/.claude writable by node" || fail "/home/node/.claude not writable by node (COPY --from=claude missing --chown)"
+docker exec "$CONTAINER_NAME" rm -f /home/node/.claude/.test-write 2>/dev/null
 
 # ── cleanup ──
 echo ""

--- a/woltspace
+++ b/woltspace
@@ -43,6 +43,7 @@ cmd="${1:-start}"
 # WOLTSPACE_LOCAL=true is equivalent to --local (sticky dev mode)
 LOCAL_BUILD="${WOLTSPACE_LOCAL:-false}"
 BUILD_BRANCH="main"
+NO_CACHE=false
 _next=""
 for arg in "$@"; do
   if [ -n "$_next" ]; then
@@ -52,6 +53,8 @@ for arg in "$@"; do
     LOCAL_BUILD=true
   elif [ "$arg" = "--branch" ]; then
     _next=branch
+  elif [ "$arg" = "--no-cache" ]; then
+    NO_CACHE=true
   fi
 done
 
@@ -68,18 +71,21 @@ _G=$'\033[0;32m'; _B=$'\033[1m'; _R=$'\033[0m'
 # --- Helpers ---
 
 _build_image() {
+  local cache_flag=""
+  [ "$NO_CACHE" = true ] && cache_flag="--no-cache"
+
   if [ "$LOCAL_BUILD" = true ]; then
     echo "  ${_D}🪵 building image from local source${_R}"
     echo "  ${_L}   felling fresh timber...${_R}"
     echo ""
-    docker build -t woltspace \
+    docker build -t woltspace $cache_flag \
       --build-arg USE_LOCAL=true \
       -f "$WOLTSPACE_DIR/container/Dockerfile" "$WOLTSPACE_DIR"
   else
     echo "  ${_D}🪵 building image (branch: $BUILD_BRANCH, latest release tag)${_R}"
     echo "  ${_L}   felling fresh timber...${_R}"
     echo ""
-    docker build -t woltspace \
+    docker build -t woltspace $cache_flag \
       --build-arg WOLTSPACE_BRANCH="$BUILD_BRANCH" \
       -f "$WOLTSPACE_DIR/container/Dockerfile" "$WOLTSPACE_DIR/container"
   fi
@@ -93,6 +99,10 @@ _start_container() {
   [ -n "$wolt_name" ] && extra_args="-e WOLT_NAME=$wolt_name"
 
   mkdir -p "$WOLTS_DIR/.claude"
+  # Ensure writable by container's node user (1000) — handles root-owned dirs from Docker
+  chown 1000:1000 "$WOLTS_DIR/.claude" 2>/dev/null \
+    || docker run --rm -v "$WOLTS_DIR/.claude:/fix" node:22-slim chown -R 1000:1000 /fix 2>/dev/null \
+    || true
   docker run -d \
     --name "$CONTAINER_NAME" \
     --env-file "$WOLTS_DIR/.env" \
@@ -472,6 +482,7 @@ RESTORE
     ;;
   *)
     echo "usage: woltspace <init|start|stop|rebuild|backup|shell|chat|logs>"
+    echo "       woltspace rebuild [--no-cache]"
     echo "       woltspace backup [tag] [--bundle]"
     exit 1
     ;;


### PR DESCRIPTION
## Summary

New users on Linux/WSL hit `PermissionError` on first boot — `scaffold_wolt` can't touch `/home/node/.claude/.first-run`. Two causes:

1. **Dockerfile**: `COPY --from=claude` without `--chown` left `/home/node/.claude` owned by root in the image layer
2. **Docker mount**: Docker auto-creates mount source dirs as root. On Linux/WSL, the bind-mounted `.claude` dir inherits root ownership — container's `node` user (UID 1000) can't write to it

**Fixes:**
- Dockerfile: add `--chown=node:node` to `COPY --from=claude`
- CLI: `chown 1000:1000` the `.claude` dir before mounting, with Docker daemon fallback for root-owned dirs
- CLI: add `--no-cache` flag (`woltspace rebuild --no-cache`) for clean builds
- Test: verify `/home/node/.claude` is writable by node

**For affected users:** `sudo chown -R $(id -u):$(id -g) ~/.woltspace/wolts/.claude` fixes it immediately. The CLI fix prevents it from recurring.

## Test plan

- [x] `bash test/test-cli.sh --local` passes (25/25 including new permissions check)
- [x] `bash test/test-cli.sh --local --no-cache` passes (clean build, no Docker cache)
- [ ] WSL user confirms fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)