### PR TITLE
feat: per-wolt .claude config isolation

### DIFF
--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -11,6 +11,7 @@ python3 "$WOLTSPACE_DIR/container/entrypoint_setup.py" --env-file "$ENV_FILE"
 source "$ENV_FILE"
 rm -f "$ENV_FILE"
 export WOLT_NAME WOLT_DIR DEV_MODE WOLF_CONFIG PYTHONPATH PATH
+export CLAUDE_CODE_DISABLE_AUTO_MEMORY=1
 
 # ── tmux ──
 tmux new-session -d -s main -c "$WOLT_DIR" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Groundwork for per-wolt `.claude/` isolation — each wolt gets its own Claude Code config directory instead of sharing a single global one.

- Disabled Claude auto-memory globally (`CLAUDE_CODE_DISABLE_AUTO_MEMORY=1`) — wolts have their own memory system at `wolt/memory/`
- Design sketch saved for UX review

## What's next

The full implementation (changing `HOME` per-wolt via `wclaude`, per-wolt `.claude/` setup in entrypoint, credential symlinks) is sketched out but not yet implemented. See `uxwolt/wolt/drafts/inheritance_sketch.md` for the full design.

## Test plan

- [ ] Rebuild with `--local` → verify auto-memory is disabled (no `~/.claude/projects/*/memory/` writes)
- [ ] Existing wolt sessions still work normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)