### PR TITLE
fix: install script uses correct default WOLTS_DIR

### DIFF
--- a/site/install.sh
+++ b/site/install.sh
@@ -17,6 +17,6 @@ else
   git clone https://github.com/jerpint/woltspace
 fi
 
-export WOLTS_DIR="${WOLTS_DIR:-$HOME/wolts}"
+export WOLTS_DIR="${WOLTS_DIR:-$HOME/.woltspace/wolts}"
 
 "$PWD/woltspace/woltspace" init


### PR DESCRIPTION
## Summary

- Install script at `site/install.sh` defaulted to `$HOME/wolts` instead of `$HOME/.woltspace/wolts`
- This mismatched the CLI default, so new users via `woltspace.com/install.sh` got wolts in the wrong location

One-line fix: `$HOME/wolts` → `$HOME/.woltspace/wolts`

## Test plan

- [ ] Run `curl -fsSL https://woltspace.com/install.sh | bash` on a clean machine after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)