### PR TITLE
fix: stale tunnel URL on stop/start + cache-bust remote builds

### DIFF
--- a/container/Dockerfile
+++ b/container/Dockerfile
@@ -66,6 +66,9 @@ ENV WORKTUI_DIR="/workspace/wolts/.worktui"
 ARG USE_LOCAL=false
 ARG WOLTSPACE_BRANCH=main
 ARG WOLTSPACE_VERSION=
+# Changing CACHE_BUST invalidates the clone layer (and everything after it)
+# but keeps heavy layers above (node, claude, apt, uv, cloudflared) cached.
+ARG CACHE_BUST=
 
 # Clone from github (default path)
 # --branch X    → use branch tip (no tag checkout)

--- a/woltspace
+++ b/woltspace
@@ -107,6 +107,7 @@ _build_image() {
     echo ""
     docker build -t woltspace $cache_flag $version_arg \
       --build-arg WOLTSPACE_BRANCH="$BUILD_BRANCH" \
+      --build-arg CACHE_BUST="$(date +%s)" \
       -f "$WOLTSPACE_DIR/container/Dockerfile" "$WOLTSPACE_DIR/container"
   fi
 }
@@ -413,6 +414,7 @@ case "$cmd" in
       fi
     else
       docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
+      rm -f "$WOLTS_DIR/.space/platform/tunnel-url" "$WOLTS_DIR/.state/tunnel-url"
       echo "  ${_D}🌙 container stopped${_R}"
       echo "  ${_L}   lodge closed for the night${_R}"
     fi


### PR DESCRIPTION
## Summary

Two CLI bugs that made `woltspace` unreliable:

- **Stale tunnel URL after stop/start** — `stop` didn't clear the tunnel-url file, so `start` displayed the old (dead) URL instead of waiting for the fresh one from cloudflared
- **Remote rebuilds served cached code** — `rebuild` (without `--local`) reused Docker's cached `git clone` layer, so new commits/tags on the remote were invisible. Added a `CACHE_BUST` build arg that invalidates the clone layer on every remote build while keeping heavy layers (node, claude, apt, uv, cloudflared) cached

## Changes

- `woltspace` CLI: clear tunnel-url on stop; pass `CACHE_BUST=$(date +%s)` for remote builds
- `container/Dockerfile`: add `ARG CACHE_BUST=` before the clone layer

## Test plan

- [ ] `woltspace stop && woltspace start` — verify fresh tunnel URL displayed
- [ ] `woltspace rebuild` — verify container gets latest code from main
- [ ] `woltspace rebuild --local` — unchanged behavior (no cache bust needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)