### PR TITLE
The wolf forgot how to script

### DIFF
--- a/container/creatures/wolf.py
+++ b/container/creatures/wolf.py
@@ -271,21 +271,44 @@ def _get_wolt_emoji(wolt_name: str) -> str:
         return "🐾"
 
 
+def dispatch_script(entry: dict) -> bool:
+    """Run a cron entry's shell command fire-and-forget. Returns True on dispatch."""
+    import subprocess
+    name = entry.get("name", "unnamed")
+    command = entry.get("command", "")
+    if not command:
+        print(f"[wolf] {name}: script action has no command", file=sys.stderr)
+        return False
+    try:
+        subprocess.Popen(["bash", "-c", command], start_new_session=True)
+        print(f"[wolf] dispatched script for {name}: {command[:80]}")
+        return True
+    except Exception as e:
+        print(f"[wolf] script dispatch error for {name}: {e}", file=sys.stderr)
+        return False
+
+
 def fire_cron(entry: dict):
-    """Execute a cron entry — dispatch session, then always notify with link."""
+    """Execute a cron entry — dispatch script or session, then notify."""
     name = entry.get("name", "unnamed")
     owner = entry.get("_owner", "?")
+    action = entry.get("action", "session")
 
-    _log_job(name, "session", event="started", owner=owner)
+    if action == "script":
+        _log_job(name, "script", event="started", owner=owner)
+        ok = dispatch_script(entry)
+        _log_job(name, "script", event="dispatched" if ok else "failed", owner=owner)
+        link = None
+    else:
+        _log_job(name, "session", event="started", owner=owner)
+        link = dispatch_session(entry)
+        _log_job(name, "session", event="dispatched", owner=owner, link=link)
 
-    # Dispatch session for the owning wolt
-    link = dispatch_session(entry)
-
-    _log_job(name, "session", event="dispatched", owner=owner, link=link)
-
-    # Build notification message
-    emoji = _get_wolt_emoji(owner)
+    # Notification (skip for script-action crons unless they have a custom notify)
     custom_msg = entry.get("notify")
+    if action == "script" and not custom_msg:
+        return
+    emoji = _get_wolt_emoji(owner)
     if custom_msg:
         notify_body = f'{emoji} {owner} has been notified: "{custom_msg}"'
     else:


### PR DESCRIPTION
## What happened

Loup wakes up on schedule, howls, marks the cron "dispatched" in `jobs.jsonl` — but nothing actually runs. Every wolt with a `"action": "script"` cron in `wolf.json` has been silently spawning empty Claude Code sessions instead of executing its shell command. The session has no `prompt`, so `dispatch_session()` bails. The session is reaped seconds later. No bash runs, no apps come back up, no digest fires, no Loucie watcher polls — but the howl keeps going every cycle so it looks fine from the outside.

This lab's apps-keepalive (Milo/`apps-keepalive.sh`) is the most visible casualty — onboarding portal, ressources, calendar widget, radicale, and four Slack/Telegram bots all silently die after the first container rebuild. La Trame's `start-apps` cron is the same. Found while testing rebuild survival after migrating to a named tunnel — apps wouldn't come back up, which led to discovering Loup wasn't actually running anything.

## Root cause

`fire_cron()` in `container/creatures/wolf.py` unconditionally calls `dispatch_session()` regardless of the `action` field:

```python
def fire_cron(entry: dict):
    ...
    _log_job(name, "session", event="started", owner=owner)
    link = dispatch_session(entry)   # <-- always session, never script
    _log_job(name, "session", event="dispatched", ...)
```

The `action: "script"` schema documented in existing `wolf.json` files across the platform (Loup, la-trame) is unimplemented — the field is read but never branched on.

## What changed

- New `dispatch_script(entry)` helper — runs `entry["command"]` via `subprocess.Popen` with `start_new_session=True` (fire-and-forget, doesn't block the wolf loop).
- `fire_cron()` now reads `entry.get("action", "session")` and routes:
  - `action: "script"` → `dispatch_script()` → logs as `action: "script"` in `jobs.jsonl`
  - anything else (including missing) → `dispatch_session()` → unchanged behavior.
- Notifications are suppressed for script crons that don't declare a `notify:` field. Heartbeat keepalives shouldn't howl every two minutes.

Backwards compatible: any cron without an explicit `action` continues to be treated as a session, matching the pre-patch behavior.

## Test plan

- [x] Wolt with `"action": "script"` (Loup's `apps-keepalive`, every 2 min): rebuild container, wait for next `*/2` tick, all 5 services come up within 15 seconds. Confirmed twice across two consecutive rebuilds.
- [x] Wolt with session-type cron (default action, prompt set): Claude Code session still spawns correctly via the original code path.
- [x] `jobs.jsonl` distinguishes `action: "script"` from `action: "session"` events.
- [x] Reproduces on v0.4.36 / current `main` (`2ca2fd4`) before the patch — every script cron in this colony's wolves was a no-op for ~6 weeks.

🐺 *the wolf can speak bash again*