### PR TITLE
wclaude: put the wolt's own .local/bin on PATH

### DIFF
--- a/container/bin/wclaude
+++ b/container/bin/wclaude
@@ -10,6 +10,10 @@
 WOLT_HOME=$(echo "$PWD" | sed -n 's|\(/workspace/wolts/[^/]*\).*|\1|p')
 if [ -n "$WOLT_HOME" ] && [ -d "$WOLT_HOME/.claude" ]; then
     export HOME="$WOLT_HOME"
+    # Claude Code auto-updates into $HOME/.local/bin. With a per-wolt HOME that dir
+    # isn't on PATH, so the image's baked claude runs instead and warns about the
+    # newer native install it can't reach. Put the wolt's own bin first.
+    export PATH="$HOME/.local/bin:$PATH"
     # Self-heal missing credentials (copy from shared seed)
     WOLT_CREDS="$WOLT_HOME/.claude/.credentials.json"
     SHARED_CREDS="/workspace/wolts/.claude/.credentials.json"


### PR DESCRIPTION
## The den had a newer claude all along 🦫

Every wolt session was greeted with:

> Native installation exists but `~/.local/bin` is not in your PATH

Claude Code auto-updates itself into `$HOME/.local/bin`. Since `wclaude` gives each wolt its own `HOME` (`/workspace/wolts/<name>`), the updated binary lands in `/workspace/wolts/<name>/.local/bin` — a dir that was never on PATH. So the image's older baked claude at `/home/node/.local/bin` kept running, spotted the newer install it couldn't reach, and complained.

Concretely, on a live container: `/home/node/.local/bin/claude` was `2.1.112` while Plume's den held `2.1.154`. The new one was right there in the den, just out of reach.

## What changed

- `wclaude` now prepends `$HOME/.local/bin` to PATH right after it sets the per-wolt HOME, so the den's own (auto-updated) claude is the one that runs — and the warning's condition is satisfied.

## Test plan

- [x] `docker exec` into the running container, set `HOME=/workspace/wolts/Plume` and `PATH="$HOME/.local/bin:$PATH"` → `which claude` resolves to the wolt's `2.1.154` and the warning is gone
- [ ] Rebuild from this branch, start a wolt session, confirm no PATH warning at startup

## One-line closer

The den's claude finally answers when called. 🦫