### PR TITLE
Apps reach their dens from every window — even the native shell

### DIFF
--- a/desktop/src-tauri/Info.plist
+++ b/desktop/src-tauri/Info.plist
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!--
+    App Transport Security exception for the local lodge.
+
+    macOS ATS auto-exempts the loopback IP (127.0.0.1) and the literal host
+    "localhost", which is why the shell can load the lodge over plain HTTP.
+    Running apps are served from *.localhost subdomains (e.g. blog.localhost:7777)
+    which ATS does NOT exempt — so without this, the WKWebView silently refuses
+    to follow the lodge's redirect to an app and the window stays put.
+
+    NSIncludesSubdomains covers every {app}.localhost host; the app subdomains
+    reached through the Cloudflare tunnel are HTTPS and need no exception.
+  -->
+  <key>NSAppTransportSecurity</key>
+  <dict>
+    <key>NSExceptionDomains</key>
+    <dict>
+      <key>localhost</key>
+      <dict>
+        <key>NSExceptionAllowsInsecureHTTPLoads</key>
+        <true/>
+        <key>NSIncludesSubdomains</key>
+        <true/>
+      </dict>
+    </dict>
+  </dict>
+</dict>
+</plist>

--- a/server/app.py
+++ b/server/app.py
@@ -1193,22 +1193,30 @@ async def serve_app(app_name: str, request: Request, path: str = ""):
 
     sub_path = "/" + path if path else "/"
 
-    # When running, redirect to the direct app port — no proxy
+    # When running, redirect to the app's own origin at root. The
+    # subdomain_proxy middleware forwards that host to the app's in-container
+    # port, so the app always sees itself at the root of its own hostname —
+    # identical behavior in a browser, the PWA, the desktop shell, and through
+    # the tunnel. We never redirect to the raw app port: it isn't published to
+    # the host (only 7777 is), so a direct-port redirect is a dead end for
+    # every client except a same-host browser that happens to expose the port.
     running = {r["name"]: r for r in running_apps()}
     run_state = running.get(app_name)
     if run_state:
-        port = run_state["port"]
         qs = f"?{request.url.query}" if request.url.query else ""
-        # Subdomain routing: redirect to app.domain (works through tunnel)
         td = tunnel_mgr.get_tunnel_domain()
         hostname = request.url.hostname or ""
-        is_local = hostname == "localhost" or hostname.endswith(".localhost")
+        is_local = hostname in ("localhost", "127.0.0.1") or hostname.endswith(".localhost")
         if td and not is_local:
-            subdomain = f"{request.url.scheme}://{app_name}.{td}{sub_path}{qs}"
-            return RedirectResponse(subdomain, status_code=302)
-        # Local: redirect to direct port (works on localhost)
-        direct = f"{request.url.scheme}://{request.url.hostname}:{port}{sub_path}{qs}"
-        return RedirectResponse(direct, status_code=302)
+            # Public/tunnel access → app subdomain on the tunnel domain.
+            target = f"{request.url.scheme}://{app_name}.{td}{sub_path}{qs}"
+        else:
+            # Local access (localhost, 127.0.0.1, or the desktop shell) → app
+            # subdomain on .localhost, preserving the lodge's port. *.localhost
+            # resolves to loopback, so WebKit/Chromium reach it without DNS.
+            port_part = f":{request.url.port}" if request.url.port else ""
+            target = f"{request.url.scheme}://{app_name}.localhost{port_part}{sub_path}{qs}"
+        return RedirectResponse(target, status_code=302)
 
     # Static fallback: serve from dist/ when not running
     dist_dir = adir / "dist"


### PR DESCRIPTION
## The pond went dark for the apps

Somewhere along the unified-navigation trail, the dens lost their doorways. Clicking a running app used to open its own space at `blog.localhost:7777` — a real origin, root and all. The navigation rework swapped that for the path route `/app/{name}/`, and the lodge, trying to be helpful, redirected clicks to the app's **raw in-container port** (`localhost:4001`). But that port is never published to the host — only `7777` is. So the redirect was a dead end everywhere except a browser that happened to expose the port. In the macOS shell it was worse: the redirect pointed at the public tunnel, or nowhere.

The colony has exactly one way apps were ever meant to be reached: the `subdomain_proxy` middleware, which takes `blog.localhost:7777` (or `blog.woltspace.com` through the tunnel) and forwards it — inside the container — to the app's port. One doorway (7777 / the tunnel), fan-out by hostname. That keeps every app at the root of its own origin, so absolute paths, cookies, and routing behave the same **in or out of woltspace**.

This PR points every client back at that doorway, and teaches the native shell to walk through it.

## What changed

- **`server/app.py` — apps redirect to their own origin, never a raw port.** `/app/{name}/` now redirects to the app subdomain: `{name}.localhost:<lodge-port>` locally, `{name}.{tunnel}` publicly — which the existing `subdomain_proxy` forwards to the in-container port. The raw-port redirect is gone; it was a dead end for every client but a lucky same-host browser. Also fixes `is_local`, which never matched `127.0.0.1` — exactly the origin the desktop shell loads from.
- **`desktop/src-tauri/Info.plist` — ATS exception for `localhost` + subdomains.** macOS App Transport Security waves through `127.0.0.1` and the literal `localhost` (how the shell reaches the lodge), but not `*.localhost`. So WebKit silently refused to follow the lodge's redirect to an app and the window never moved. The exception lets the shell take the same path a browser does. Tunnel app subdomains are HTTPS and need nothing.

Together: apps behave identically in a browser, the PWA, the desktop shell, and through the Cloudflare tunnel.

## Why it's shippable, not a per-user hack

- The redirect fix rides inside the **Docker image** — every rebuild/update carries it.
- The ATS exception is compiled into the **`.app` bundle** — every install carries it.
- No per-machine settings, no manual steps. (Local unsigned iteration still needs a quarantine strip; a notarized release doesn't.)

## Test plan

- [x] `/app/blog/` → `302 → http://blog.localhost:7777/` (was `→ localhost:4001`); path + query preserved
- [x] `Host: blog.localhost:7777` still serves the app `200` (proxy path intact)
- [x] Loads in a browser at `localhost:7777`
- [x] Loads through the Cloudflare tunnel (`blog.<domain>`)
- [x] ATS key verified present in the bundled `Info.plist`
- [x] **Loads in the rebuilt desktop shell** — click → app renders in-window
- [ ] `bash test/run-tests.sh unit` on CI

## One-line closer

🦫 the dens have doorways again — and the native shell finally knows how to knock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)