### PR TITLE
two woltspaces, one clearing

### DIFF
--- a/container/bin/woltspace
+++ b/container/bin/woltspace
@@ -191,6 +191,128 @@ def cmd_auto_revoke(args):
 
 LIFECYCLE = {"start", "stop", "rebuild", "backup", "shell", "chat", "logs", "init", "update"}
 
+# The nouns this client actually serves over HTTP. Everything else belongs to
+# the real CLI — `doctor`, `paths`, `serve`, `restore`, and the whole lifecycle
+# set. In the container "elsewhere" means the host; natively it means the python
+# CLI sitting a few directories up from this script.
+LOCAL_NOUNS = {"session", "status", "auto", "tui"}
+
+
+def _running_in_container():
+    """Whether this process is inside the woltspace image.
+
+    Not answerable from this script's own path: the image pins the wheel bundle
+    at /workspace/woltspace with a symlink, so `__file__` resolves into
+    `site-packages/woltspace/_bundle/container/bin` in *both* worlds. The
+    control plane stamps WOLTSPACE_ISOLATION into every session and connector
+    environment, and the image's fixed mount points answer for the bare
+    `docker exec` shells that carry no environment at all.
+    """
+    isolation = os.environ.get("WOLTSPACE_ISOLATION", "").strip().lower()
+    if isolation == "external":
+        return True
+    if isolation == "host":
+        return False
+    return os.path.isdir("/workspace/woltspace") and os.path.isdir("/workspace/wolts")
+
+
+def _is_python_program(path):
+    """Whether a file is a python entry point rather than a shell launcher.
+
+    The container-era bash launcher is also called `woltspace` and is also on
+    plenty of PATHs. Handing it our arguments is the whole accident this guard
+    exists to prevent, so a candidate has to look like the console script the
+    wheel installs.
+    """
+    try:
+        with open(path, "rb") as handle:
+            return b"python" in handle.readline()
+    except OSError:
+        return False
+
+
+def _native_cli():
+    """Argv prefix for the native CLI installed beside this bundle, or None.
+
+    Preferred answer is arithmetic, not search: this script lives at
+    `<venv>/lib/pythonX.Y/site-packages/woltspace/_bundle/container/bin/woltspace`,
+    so the console script is `<venv>/bin/woltspace` — the exact same version,
+    with no PATH guessing and no chance of picking up a different install.
+    """
+    here = os.path.realpath(__file__)
+    bin_dir = os.path.dirname(here)
+    bundle = os.path.dirname(os.path.dirname(bin_dir))
+    site_packages = os.path.dirname(os.path.dirname(bundle))
+    if os.path.basename(bundle) == "_bundle" and os.path.basename(site_packages) == "site-packages":
+        # <venv>/lib/pythonX.Y/site-packages -> <venv>
+        venv = os.path.dirname(os.path.dirname(os.path.dirname(site_packages)))
+        script = os.path.join(venv, "bin", "woltspace")
+        if os.access(script, os.X_OK) and os.path.realpath(script) != here:
+            return [script]
+        for name in ("python", "python3"):
+            interpreter = os.path.join(venv, "bin", name)
+            if os.access(interpreter, os.X_OK):
+                return [interpreter, "-m", "woltspace"]
+    return _native_cli_on_path(here)
+
+
+def _native_cli_on_path(here):
+    """Fallback for installs that are not venv-shaped (pip --user, a checkout).
+
+    Skips this script, any other `container/bin/woltspace`, and anything that
+    is not a python program — which is how the bash docker launcher gets
+    excluded even when it sits first on PATH.
+    """
+    for entry in os.environ.get("PATH", "").split(os.pathsep):
+        if not entry:
+            continue
+        candidate = os.path.join(entry, "woltspace")
+        if os.path.isdir(candidate) or not os.access(candidate, os.X_OK):
+            continue
+        real = os.path.realpath(candidate)
+        if real == here:
+            continue
+        parent = os.path.dirname(real)
+        if os.path.basename(parent) == "bin" and \
+                os.path.basename(os.path.dirname(parent)) == "container":
+            continue
+        if _is_python_program(real):
+            return [candidate]
+    return None
+
+
+def _delegate(argv):
+    """Hand a verb we do not serve to whoever actually owns it.
+
+    In the container that is the host, and the message is the one this client
+    has always printed. Natively it is the python CLI, and we *exec* it: the
+    old message ("run it on the host where docker lives") is not just useless
+    on a native colony, it is the instruction that boots a second one.
+    """
+    verb = argv[0]
+    if _running_in_container():
+        if verb in LIFECYCLE:
+            print(f"'{verb}' is a host lifecycle command — run it on the host "
+                  f"where docker lives, not inside the container.", file=sys.stderr)
+            sys.exit(2)
+        return
+    cli = _native_cli()
+    if cli:
+        os.execv(cli[0], [*cli, *argv])
+    print(
+        f"'{verb}' belongs to the native woltspace CLI, not to this bundled "
+        f"control client ({os.path.realpath(__file__)}), which is on your PATH "
+        f"so that `notify` and `push-view` resolve inside sessions.\n"
+        f"The native CLI was not found beside this bundle. Install it with "
+        f"`uv tool install woltspace` and call it by full path, e.g.\n"
+        f"  ~/.local/bin/woltspace {' '.join(argv)}\n"
+        f"Do not reach for the container-era bash launcher on a native host: it "
+        f"boots a second colony against the same data root, the same port and "
+        f"the same bot token.",
+        file=sys.stderr,
+    )
+    sys.exit(2)
+
 
 def main():
     p = argparse.ArgumentParser(prog="woltspace", description="woltspace control CLI")
@@ -257,11 +379,11 @@ def main():
             sys.exit(1)
         os.execvp(tui, [tui, *argv[1:]])
 
-    # Friendly hint: lifecycle verbs belong to the host launcher, not in-container.
-    if argv and argv[0] in LIFECYCLE:
-        print(f"'{argv[0]}' is a host lifecycle command — run it on the host "
-              f"where docker lives, not inside the container.", file=sys.stderr)
-        sys.exit(2)
+    # Anything we do not serve ourselves goes to whoever does — the host
+    # launcher in the container, the native CLI on a native install.
+    if argv and (argv[0] == "--version" or
+                 (not argv[0].startswith("-") and argv[0] not in LOCAL_NOUNS)):
+        _delegate(argv)
 
     args = p.parse_args(argv)
     if not getattr(args, "func", None):

--- a/docs/native-and-container.md
+++ b/docs/native-and-container.md
@@ -160,6 +160,25 @@ its port. Switch it off with `channels.tui.enabled = false` or
 > this document mean. **Inside the container, read connector state with
 > `curl -s localhost:7777/health | jq .connectors`** — `woltspace status` there
 > is the other program and will answer, confidently, about something else.
+>
+> On a *native* install the thin client is on PATH too — the wheel bundle's
+> `container/bin` is what puts `notify` and `push-view` in front of a session —
+> and it can win the race with `~/.local/bin`. So it detects a native install
+> (`WOLTSPACE_ISOLATION`, else the image's fixed `/workspace` mount points) and
+> execs the console script sitting at `<venv>/bin/woltspace` for every verb it
+> does not serve: the whole lifecycle set plus `doctor`, `paths`, `serve`,
+> `restore`, `--version`. It keeps `session`, `status`, `auto` and `tui` for
+> itself, because the native CLI has no `session` noun and wolts message each
+> other through it. In the container nothing changed: lifecycle verbs still get
+> the "run it on the host where docker lives" refusal.
+>
+> The bash launcher has the matching guard from the other side. Before its first
+> `docker` verb it reads `<wolts>/.space/platform/control-plane.json`, and if a
+> live pid owns that data root with `"isolation": "host"`, it refuses to boot.
+> It has to be a refusal rather than a warning: `docker run` mounts the same
+> wolts directory, binds the same port, and loads the same `.env` — so the
+> second colony comes up holding the *same* bot token, and two long-polls on one
+> token trade 409s while the human watches a server they did not start.
 
 Configure it in the data root the control plane owns —
 `<wolts>/.space/platform/config.json`:

--- a/docs/native-first-run.md
+++ b/docs/native-first-run.md
@@ -75,11 +75,25 @@ later.
 > the `export PATH=...` line it prints (or run `uv tool update-shell`) and open
 > a new shell.
 
-> **Three programs are called `woltspace`**, and one of them may already be on
-> your PATH: the bash Docker launcher at the root of this checkout. If your
-> shell rc puts the checkout ahead of `~/.local/bin`, plain `woltspace` keeps
-> running the container CLI. `which -a woltspace` shows the order; until you fix
-> it, call the native one as `~/.local/bin/woltspace` or alias it.
+> **Three programs are called `woltspace`**, and on a native install two of
+> them can sit ahead of the one you just installed:
+>
+> 1. `<bundle>/container/bin/woltspace` — the thin HTTP control client. It is on
+>    every session's PATH by design, because that is the directory `notify`,
+>    `push-view` and `session-reg` come from. It now recognises a native install
+>    and execs the console script beside it for anything it does not serve
+>    itself, so `woltspace start` and `woltspace doctor` reach the right program
+>    even when this copy wins the PATH race.
+> 2. `woltspace` at the root of a checkout — the container-era **bash Docker
+>    launcher**. If your shell rc puts the checkout ahead of `~/.local/bin`
+>    (`export PATH="$HOME/woltspace:$PATH"` is the usual line), plain
+>    `woltspace start` runs *this*, and it will try to boot a container. It now
+>    refuses when a native control plane owns the data root — but the launcher
+>    is not the CLI you want on a native host either way.
+> 3. `~/.local/bin/woltspace` — the one you want.
+>
+> `which -a woltspace` shows the order. If a checkout is winning, drop that
+> `export PATH` line from your shell rc, or move it after `~/.local/bin`.
 
 The TUI install also brings `woltspace-tui-service`, the pty bridge behind the
 browser terminal. Check it landed too:

--- a/test/test_native_cli_shadowing.py
+++ b/test/test_native_cli_shadowing.py
@@ -1,0 +1,321 @@
+"""The name `woltspace` must not mean "boot Docker" on a native colony.
+
+Two scripts in this repo answer to `woltspace` and neither of them is the CLI a
+native user installed:
+
+  * `container/bin/woltspace` — the thin HTTP control client. It ships inside
+    the wheel's `_bundle`, and that bundle's `container/bin` is prepended to
+    every native session's PATH so `notify` and `push-view` resolve. The client
+    rides along and shadows the console script.
+  * `woltspace` at the root of this checkout — the container-era bash launcher,
+    which drives Docker.
+
+Together they made a live accident: `woltspace start` on a native mac hit the
+bundled client, which said "run it on the host where docker lives", and the
+launcher that answers to that advice booted a whole second colony on the same
+data root, port, and Telegram token.
+
+These cover both seams: the client delegates instead of misdirecting, and the
+launcher refuses to boot over a live native colony.
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[1]
+CLIENT = ROOT / "container" / "bin" / "woltspace"
+LAUNCHER = ROOT / "woltspace"
+
+
+# Every probe runs with a PATH that cannot see the real install. A test that
+# leaks the host's PATH does not just test the wrong thing — it dispatches
+# lifecycle verbs at the colony the developer is standing in.
+SYSTEM_PATH = f"/usr/bin{os.pathsep}/bin"
+
+
+def _clean_env(**extra):
+    """The ambient environment minus every woltspace path variable."""
+    env = {
+        key: value
+        for key, value in os.environ.items()
+        if not key.startswith(("WOLTS_", "WOLTSPACE_", "WOLT_"))
+    }
+    env["PATH"] = SYSTEM_PATH
+    env.update(extra)
+    return env
+
+
+# --------------------------------------------------------------------------
+# The bundled control client
+# --------------------------------------------------------------------------
+
+def _fake_bundle(tmp_path, *, cli_body=None, interpreter=True):
+    """A venv-shaped install: <venv>/lib/pythonX.Y/site-packages/woltspace/_bundle.
+
+    The client's whole point is that it can find its own sibling console script
+    by arithmetic on its path, so the test has to reproduce the real shape.
+    """
+    venv = tmp_path / "venv"
+    site_packages = venv / "lib" / "python3.13" / "site-packages"
+    bin_dir = site_packages / "woltspace" / "_bundle" / "container" / "bin"
+    bin_dir.mkdir(parents=True)
+    client = bin_dir / "woltspace"
+    client.write_text(CLIENT.read_text())
+    client.chmod(0o755)
+
+    (venv / "bin").mkdir(parents=True)
+    if interpreter:
+        script = venv / "bin" / "woltspace"
+        script.write_text(cli_body or (
+            "#!/bin/sh\n"
+            'printf \'{"native": true, "argv": "%s"}\\n\' "$*"\n'
+        ))
+        script.chmod(0o755)
+    return client, venv
+
+
+def test_native_lifecycle_verb_execs_the_console_script_beside_the_bundle(tmp_path):
+    client, venv = _fake_bundle(tmp_path)
+    result = subprocess.run(
+        [sys.executable, str(client), "start", "--port", "8080"],
+        capture_output=True, text=True, timeout=30,
+        env=_clean_env(WOLTSPACE_ISOLATION="host"),
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["native"] is True
+    assert payload["argv"] == "start --port 8080"
+    # And emphatically not the old misdirection.
+    assert "docker lives" not in result.stderr
+
+
+@pytest.mark.parametrize("verb", ["doctor", "paths", "serve", "restore", "--version"])
+def test_native_delegates_every_verb_it_does_not_serve(verb, tmp_path):
+    """`woltspace doctor` used to die on an argparse error. It is the CLI's now."""
+    client, _ = _fake_bundle(tmp_path)
+    result = subprocess.run(
+        [sys.executable, str(client), verb],
+        capture_output=True, text=True, timeout=30,
+        env=_clean_env(WOLTSPACE_ISOLATION="host"),
+    )
+    assert result.returncode == 0, result.stderr
+    assert json.loads(result.stdout)["argv"] == verb
+    assert "invalid choice" not in result.stderr
+
+
+def test_native_refuses_loudly_when_no_console_script_can_be_found(tmp_path):
+    """No silent fallthrough, and no pointer at the docker launcher."""
+    client, _ = _fake_bundle(tmp_path, interpreter=False)
+    empty_bin = tmp_path / "empty"
+    empty_bin.mkdir()
+    result = subprocess.run(
+        [sys.executable, str(client), "start"],
+        capture_output=True, text=True, timeout=30,
+        env=_clean_env(WOLTSPACE_ISOLATION="host", PATH=str(empty_bin)),
+    )
+    assert result.returncode == 2
+    assert "belongs to the native woltspace CLI" in result.stderr
+    assert "uv tool install woltspace" in result.stderr
+    assert "second colony" in result.stderr
+
+
+def test_path_fallback_skips_the_bash_launcher(tmp_path):
+    """A launcher-shaped `woltspace` first on PATH must never receive our argv.
+
+    This is the ordering the person who hit this had: the container-era bash
+    script ahead of `~/.local/bin`.
+    """
+    client, _ = _fake_bundle(tmp_path, interpreter=False)
+
+    bash_first = tmp_path / "checkout"
+    bash_first.mkdir()
+    launcher = bash_first / "woltspace"
+    launcher.write_text("#!/bin/bash\necho 'BOOTED DOCKER'\n")
+    launcher.chmod(0o755)
+
+    real = tmp_path / "local-bin"
+    real.mkdir()
+    console = real / "woltspace"
+    console.write_text("#!/usr/bin/env python3\nprint('NATIVE CLI')\n")
+    console.chmod(0o755)
+
+    result = subprocess.run(
+        [sys.executable, str(client), "start"],
+        capture_output=True, text=True, timeout=30,
+        env=_clean_env(
+            WOLTSPACE_ISOLATION="host",
+            PATH=f"{bash_first}{os.pathsep}{real}{os.pathsep}{SYSTEM_PATH}",
+        ),
+    )
+    assert result.returncode == 0, result.stderr
+    assert "NATIVE CLI" in result.stdout
+    assert "BOOTED DOCKER" not in result.stdout
+
+
+def test_container_keeps_the_host_lifecycle_message(tmp_path):
+    """Container mode is unchanged — same text, same exit code, no exec."""
+    client, _ = _fake_bundle(tmp_path)
+    result = subprocess.run(
+        [sys.executable, str(client), "start"],
+        capture_output=True, text=True, timeout=30,
+        env=_clean_env(WOLTSPACE_ISOLATION="external"),
+    )
+    assert result.returncode == 2
+    assert "is a host lifecycle command" in result.stderr
+    assert "docker lives" in result.stderr
+    assert result.stdout == ""
+
+
+def test_container_is_detected_from_mount_points_without_any_environment(tmp_path):
+    """A bare `docker exec` shell carries no WOLTSPACE_ISOLATION.
+
+    The bundle path cannot answer this — the image symlinks
+    /workspace/woltspace at the very same `_bundle` — so the fixed mount points
+    have to. Skipped off a container, where they do not exist.
+    """
+    if not (os.path.isdir("/workspace/woltspace") and os.path.isdir("/workspace/wolts")):
+        pytest.skip("not running inside the woltspace image")
+    client, _ = _fake_bundle(tmp_path)
+    result = subprocess.run(
+        [sys.executable, str(client), "start"],
+        capture_output=True, text=True, timeout=30, env=_clean_env(),
+    )
+    assert result.returncode == 2
+    assert "is a host lifecycle command" in result.stderr
+
+
+def test_control_nouns_stay_local_and_never_delegate(tmp_path):
+    """`session send` is how wolts talk to each other; it must keep working.
+
+    The native CLI has no `session` noun at all, so delegating it would break
+    IWCL on every native colony.
+    """
+    client, _ = _fake_bundle(tmp_path)
+    result = subprocess.run(
+        [sys.executable, str(client), "session", "list"],
+        capture_output=True, text=True, timeout=30,
+        env=_clean_env(
+            WOLTSPACE_ISOLATION="host",
+            WOLTSPACE_API="http://127.0.0.1:1",  # nothing listening
+        ),
+    )
+    # Handled here: it tried to reach the API rather than exec'ing the CLI.
+    assert result.returncode == 2
+    assert "cannot reach woltspace API" in result.stderr
+
+
+# --------------------------------------------------------------------------
+# The container-era bash launcher
+# --------------------------------------------------------------------------
+
+def _owner_record(wolts_dir, **fields):
+    platform = wolts_dir / ".space" / "platform"
+    platform.mkdir(parents=True, exist_ok=True)
+    record = {
+        "instance_id": "af6ee123774a427488d39151aacfab27",
+        "pid": os.getpid(),
+        "started_at": 1788757804,
+        "endpoint": "http://127.0.0.1:7777",
+        "isolation": "host",
+        "hostname": "test-host",
+    }
+    record.update(fields)
+    (platform / "control-plane.json").write_text(json.dumps(record, indent=2))
+
+
+def _lodge(tmp_path):
+    """A wolts dir with one wolt in it, so the launcher's own gate lets us in."""
+    wolts_dir = tmp_path / "wolts"
+    (wolts_dir / "testwolt" / "wolt").mkdir(parents=True)
+    return wolts_dir
+
+
+def _launch(wolts_dir, verb="start"):
+    fake_bin = wolts_dir.parent / "fake-bin"
+    fake_bin.mkdir(exist_ok=True)
+    # A docker that screams if the guard ever lets it through.
+    docker = fake_bin / "docker"
+    docker.write_text("#!/bin/sh\necho 'DOCKER INVOKED' >&2\nexit 0\n")
+    docker.chmod(0o755)
+    return subprocess.run(
+        ["bash", str(LAUNCHER), verb],
+        capture_output=True, text=True, timeout=60,
+        env=_clean_env(
+            WOLTS_DIR=str(wolts_dir),
+            PATH=f"{fake_bin}{os.pathsep}{SYSTEM_PATH}",
+        ),
+    )
+
+
+@pytest.mark.parametrize("verb", ["start", "rebuild", "init"])
+def test_launcher_refuses_to_boot_over_a_live_native_colony(verb, tmp_path):
+    wolts_dir = _lodge(tmp_path)
+    _owner_record(wolts_dir)
+    result = _launch(wolts_dir, verb)
+    assert result.returncode == 1, result.stdout
+    assert "this clearing is already taken" in result.stdout
+    assert "two bots on one token" in result.stdout
+    assert str(wolts_dir) in result.stdout
+    # Prevented, not warned about: docker never ran.
+    assert "DOCKER INVOKED" not in result.stderr
+
+
+def test_launcher_refusal_points_at_the_native_cli_and_an_escape_hatch(tmp_path):
+    wolts_dir = _lodge(tmp_path)
+    _owner_record(wolts_dir)
+    out = _launch(wolts_dir).stdout
+    assert "woltspace stop" in out
+    assert "which -a woltspace" in out
+    assert "WOLTS_DIR=" in out
+
+
+def test_launcher_still_boots_when_the_owner_is_a_container(tmp_path):
+    """Container mode unchanged: an "external" owner is this script's own work."""
+    wolts_dir = _lodge(tmp_path)
+    _owner_record(wolts_dir, isolation="external")
+    result = _launch(wolts_dir)
+    assert "this clearing is already taken" not in result.stdout
+
+
+def test_launcher_ignores_a_stale_native_record(tmp_path):
+    """A dead pid must not wedge the launcher forever."""
+    wolts_dir = _lodge(tmp_path)
+    _owner_record(wolts_dir, pid=2 ** 22)  # above any pid_max, cannot be alive
+    result = _launch(wolts_dir)
+    assert "this clearing is already taken" not in result.stdout
+
+
+def test_launcher_ignores_a_missing_record(tmp_path):
+    wolts_dir = _lodge(tmp_path)
+    result = _launch(wolts_dir)
+    assert "this clearing is already taken" not in result.stdout
+
+
+# --------------------------------------------------------------------------
+# Why the shadowing happens at all
+# --------------------------------------------------------------------------
+
+def test_session_path_still_carries_the_bundle_bin(tmp_path):
+    """The prepend stays — `notify` and `push-view` depend on it.
+
+    The fix is that the client at the front of that directory now behaves like
+    the CLI it shadows, not that we stop shipping the directory.
+    """
+    sys.path.insert(0, str(ROOT / "container" / "lib"))
+    from session_runtime import _session_env_value  # noqa: E402
+
+    install_root = tmp_path / "install"
+    (install_root / "container" / "bin").mkdir(parents=True)
+    os.environ["WOLTSPACE_DIR"] = str(install_root)
+    try:
+        adjusted = _session_env_value("PATH", "/usr/bin")
+        assert adjusted.startswith(str(install_root / "container" / "bin"))
+        # Idempotent — copies must not stack across restarts.
+        assert _session_env_value("PATH", adjusted) == adjusted
+    finally:
+        os.environ.pop("WOLTSPACE_DIR", None)

--- a/woltspace
+++ b/woltspace
@@ -87,6 +87,56 @@ _G=$'\033[0;32m'; _B=$'\033[1m'; _R=$'\033[0m'
 
 # --- Helpers ---
 
+# The native control plane writes its ownership record here — instance id, pid,
+# endpoint, and the isolation mode it runs in. A record whose isolation is
+# "host" and whose pid is still alive means a *native* woltspace owns this data
+# root right now.
+_native_owner_field() {
+  sed -n "s/.*\"$1\"[[:space:]]*:[[:space:]]*\"\{0,1\}\([^\",}]*\)\"\{0,1\}.*/\1/p" \
+    "$WOLTS_DIR/.space/platform/control-plane.json" 2>/dev/null | head -1
+}
+
+# Refuse to boot the container over a live native colony.
+#
+# This is not a cosmetic conflict. `docker run` below mounts the same
+# $WOLTS_DIR, binds the same port, and loads the same $WOLTS_DIR/.env — so the
+# second colony comes up with the *same* Telegram token as the first, and the
+# two bots then fight over one long-poll with 409s while the human watches a
+# server that isn't the one they started. A warning after the fact does not
+# help: by then both are running. So this exits before the first docker verb.
+_refuse_over_native_colony() {
+  [ -f "$WOLTS_DIR/.space/platform/control-plane.json" ] || return 0
+  local isolation pid endpoint
+  isolation="$(_native_owner_field isolation)"
+  [ "$isolation" = "host" ] || return 0
+  pid="$(_native_owner_field pid)"
+  endpoint="$(_native_owner_field endpoint)"
+  case "$pid" in ''|*[!0-9]*) return 0 ;; esac
+  kill -0 "$pid" 2>/dev/null || return 0
+
+  echo ""
+  printf "  %b🛑%b  %bthis clearing is already taken%b\n\n" "${_D}" "${_R}" "${_B}${_D}" "${_R}"
+  echo "  ${_L}   one lodge to a pond${_R}"
+  echo ""
+  echo "  A native woltspace owns ${_C}$WOLTS_DIR${_R} — PID $pid, serving"
+  echo "  ${_C}${endpoint:-http://127.0.0.1:${WOLTSPACE_PORT:-7777}}${_R}."
+  echo ""
+  echo "  Starting the container here would mount that same wolts directory,"
+  echo "  bind that same port, and load that same .env — two bots on one token"
+  echo "  answering with 409s. Not doing that."
+  echo ""
+  echo "  ${_C}native lifecycle lives in the python CLI, not in this script:${_R}"
+  echo "    woltspace status      ${_D}# who owns this data root${_R}"
+  echo "    woltspace stop        ${_D}# stop the native control plane${_R}"
+  echo "  ${_D}(if plain \`woltspace\` lands back here, that CLI is the one uv"
+  echo "   installed — usually ~/.local/bin/woltspace. \`which -a woltspace\`.)${_R}"
+  echo ""
+  echo "  ${_D}to run the container alongside it, give it its own data root:${_R}"
+  echo "    WOLTS_DIR=~/.woltspace/container-wolts $0 $cmd"
+  echo ""
+  exit 1
+}
+
 _build_image() {
   local cache_flag=""
   [ "$NO_CACHE" = true ] && cache_flag="--no-cache"
@@ -124,6 +174,7 @@ _build_image() {
 
 _start_container() {
   local wolt_name="${1:-}"
+  _refuse_over_native_colony
   docker rm -f "$CONTAINER_NAME" 2>/dev/null || true
 
   local extra_args=""
@@ -281,6 +332,7 @@ if [ "$cmd" = "init" ]; then
     exit 1
   fi
 
+  _refuse_over_native_colony
   _setup_path
 
   # Detect existing lodge (wolts or just scaffold from prior init)
@@ -592,6 +644,7 @@ RESTORE
     echo ""
     ;;
   rebuild)
+    _refuse_over_native_colony
     # Resolve version: --version > --latest > current container version
     CURRENT_VERSION=""
     if [ -n "$BUILD_VERSION" ]; then
@@ -624,6 +677,7 @@ RESTORE
     _show_url
     ;;
   start)
+    _refuse_over_native_colony
     printf "\n  %b🦫%b  %b\n\n" "${_L}" "${_R}" "${_B}${_G}woltspace${_R}"
     if [ "$LOCAL_BUILD" = true ]; then
       echo "  ${_D}🪵 local build — $WOLTSPACE_DIR${_R}"


### PR DESCRIPTION
Tonight a native colony was running fine on 7777. Someone typed `woltspace start`. The lodge answered:

> `'start' is a host lifecycle command — run it on the host where docker lives, not inside the container.`

That is not the native CLI talking. Three programs answer to the name `woltspace`, and on a native mac the one the human installed comes **last**:

```
$ which -a woltspace
.../site-packages/woltspace/_bundle/container/bin/woltspace   ← the thin HTTP client
/Users/jerpint/woltspace/woltspace                            ← the container-era bash launcher
/Users/jerpint/.local/bin/woltspace                           ← the one they wanted
```

The bundle's `container/bin` is on PATH **by design** — it is the directory `notify`, `push-view`, `session-reg` and the harness wrappers come from, and `_session_env_value` in `container/lib/session_runtime.py` prepends it to every native session. The thin client rides along in that directory and shadows the console script.

So the human followed the advice they were given, found the launcher that drives Docker, and booted a whole second colony — `docker run` mounting the same `$WOLTS_DIR`, binding the same 7777, and loading the same `$WOLTS_DIR/.env`. Two Telegram bots came up holding **one token** and started trading 409s over a single long-poll, while the human watched a server that wasn't theirs.

Nobody did anything wrong. The colony gave bad directions and then honoured them.

## What changed

**The bundled client learns where it is.** `container/bin/woltspace` now keeps only the nouns it actually serves over HTTP — `session`, `status`, `auto`, `tui` — and hands everything else to whoever owns it. In the container that is still the host, with the same message and the same exit code, byte for byte. Natively it *execs* the real CLI.

Finding it is arithmetic, not search: the script sits at `<venv>/lib/pythonX.Y/site-packages/woltspace/_bundle/container/bin/woltspace`, so the console script is `<venv>/bin/woltspace` — the exact same version, no PATH guessing, no chance of grabbing a different install. There is a PATH fallback for non-venv shapes that skips itself, any other `container/bin/woltspace`, and anything without a python shebang — which is how the bash launcher gets excluded even sitting first. If nothing can be found it refuses loudly with the full path to itself and a pointer at `~/.local/bin/woltspace`; it never falls through.

Detecting native could **not** come from the script's own path: the image symlinks `/workspace/woltspace` at that very same `_bundle`, so `__file__` resolves identically in both worlds. It reads `WOLTSPACE_ISOLATION`, which the control plane stamps into every session and connector, and falls back to the image's fixed `/workspace/woltspace` + `/workspace/wolts` mount points for the bare `docker exec` shells that carry no environment.

`session` stays local deliberately. The native CLI has no `session` noun at all — delegating it would break IWCL on every native colony.

**The launcher learns to stand down.** Before its first `docker` verb — `start`, `rebuild`, `init`, and the resume branch — the bash launcher reads `<wolts>/.space/platform/control-plane.json` and refuses if a *live* pid owns that data root with `"isolation": "host"`:

```
  🛑  this clearing is already taken

     one lodge to a pond

  A native woltspace owns /Users/jerpint/.woltspace/wolts — PID 42837, serving
  http://127.0.0.1:7777.

  Starting the container here would mount that same wolts directory,
  bind that same port, and load that same .env — two bots on one token
  answering with 409s. Not doing that.
```

It refuses rather than warns because a warning arrives after both colonies are up and the token is already contested. A dead pid or a container-owned (`"isolation": "external"`) record does not block anything, so nothing gets wedged. The honest escape hatch is the one the message prints: give the container its own `WOLTS_DIR`.

## Why the guard and not just PATH ordering

Reordering PATH only fixes the PATHs we assemble. It does nothing for the human whose own shell rc puts a checkout first — which is exactly the ordering that caused tonight. The guard travels with the artifact, so it protects orderings we will never see. The prepend in `session_runtime` stays untouched (a test pins it): `notify` and `push-view` depend on it, and with the guard in place the directory winning the race no longer changes what `woltspace` means.

## Test plan

`test/test_native_cli_shadowing.py` — 18 passed, 1 skipped (container-only mount-point probe):

- native lifecycle verbs exec the console script beside the bundle, with argv intact
- `doctor`, `paths`, `serve`, `restore`, `--version` all delegate (`woltspace doctor` used to die on an argparse error)
- a launcher-shaped `woltspace` first on PATH never receives our argv — tonight's exact ordering, asserted
- no console script found → exit 2 with the pointer, never a fallthrough
- container mode unchanged: same text, same exit 2, no exec
- `session list` stays local (reaches for the API instead of delegating)
- launcher refuses over a live native colony for `start` / `rebuild` / `init`, with a fake `docker` on PATH asserting it is **never invoked**
- launcher still boots over an `external` record, a stale pid, and a missing record

Plus a live dry run against the actual running colony with a fake `docker` on PATH: refused, exit 1, docker never called.

Adjacent suites green — `test_vulture`, `test_native_layout`, `test_container_entrypoint`, `test_session_runtime` (its three tmux-paste tests fail identically on untouched `codexw/native-woltspace`; pre-existing flake, not from this branch).

## Finding, not fixed here

The bad ordering in the human's interactive shell is `export PATH="$HOME/woltspace:$PATH"` at `~/.zshrc:685`, under a `# wolts` comment — hand-added, not written by any installer or migration. In a clean interactive shell that makes the **bash Docker launcher** win outright. The bundle's `container/bin` is not in that shell at all; it is in *session* PATHs, inherited from the control plane's prepend. Both docs boxes now spell out all three programs and say to drop or demote that line — no dotfile was touched.

🦫 the lodge stopped giving directions to the wrong pond.
