### PR TITLE
Default native Codex wolts to guarded auto-review

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,7 @@ macOS native shell. See [Client surfaces and navigation](docs/client-surfaces.md
 for the cross-client ownership and navigation contract.
 
 - **Sites** (`wolts/{wolt}/site/`) — lightweight per-wolt workspace. Static HTML/CSS/JS served directly from disk by the FastAPI server, with livereload baked in via an injected client wired to a server-side file watcher. No per-site process or port. Code: `container/lib/sites.py`, served at `/wolt/{name}/site/`.
-- **Apps** (`wolts/apps/{name}/`) — full programs with their own server, deps, and `woltspace.json` manifest. The server starts/stops them; their ports are tracked in `.space/apps/`. Apps that set `public: true` get a Cloudflare tunnel automatically and survive container restarts via apps autorestore. App-scoped agent sessions use this same shared path. Native Codex Guarded mode adds `wolts/apps/` as a writable root without granting sibling wolt homes or `.space`. Code: `container/lib/apps.py` and `container/lib/execution_policy.py`.
+- **Apps** (`wolts/apps/{name}/`) — full programs with their own server, deps, and `woltspace.json` manifest. The server starts/stops them; their ports are tracked in `.space/apps/`. Apps that set `public: true` get a Cloudflare tunnel automatically and survive container restarts via apps autorestore. App-scoped agent sessions use this same shared path. Native Codex Guarded mode adds `wolts/apps/` as a writable root without granting sibling wolt homes or `.space`. A wolt's optional `execution_policy` in `wolt/wolt.json` is its persistent, self-managed default for future sessions; explicit per-spawn overrides still win. Code: `container/lib/apps.py` and `container/lib/execution_policy.py`.
 
 ### Subdomain proxy
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -168,7 +168,7 @@ macOS native shell. See [Client surfaces and navigation](docs/client-surfaces.md
 for the cross-client ownership and navigation contract.
 
 - **Sites** (`wolts/{wolt}/site/`) — lightweight per-wolt workspace. Static HTML/CSS/JS served directly from disk by the FastAPI server, with livereload baked in via an injected client wired to a server-side file watcher. No per-site process or port. Code: `container/lib/sites.py`, served at `/wolt/{name}/site/`.
-- **Apps** (`wolts/apps/{name}/`) — full programs with their own server, deps, and `woltspace.json` manifest. The server starts/stops them; their ports are tracked in `.space/apps/`. Apps that set `public: true` get a Cloudflare tunnel automatically and survive container restarts via apps autorestore. Code: `container/lib/apps.py`.
+- **Apps** (`wolts/apps/{name}/`) — full programs with their own server, deps, and `woltspace.json` manifest. The server starts/stops them; their ports are tracked in `.space/apps/`. Apps that set `public: true` get a Cloudflare tunnel automatically and survive container restarts via apps autorestore. App-scoped agent sessions use this same shared path. Native Codex Guarded mode adds `wolts/apps/` as a writable root without granting sibling wolt homes or `.space`. Code: `container/lib/apps.py` and `container/lib/execution_policy.py`.
 
 ### Subdomain proxy
 

--- a/container/lib/execution_policy.py
+++ b/container/lib/execution_policy.py
@@ -1,4 +1,4 @@
-"""Explicit session permissions and repository-scoped Auto consent."""
+"""Harness-aware session permissions and repository-scoped Auto consent."""
 
 from __future__ import annotations
 
@@ -12,9 +12,9 @@ from pathlib import Path
 from session_targets import SessionTarget
 
 
-POLICY_VERSION = 1
+POLICY_VERSION = 2
 VALID_ISOLATION = {"external", "host"}
-VALID_MODES = {"prompt", "auto"}
+VALID_MODES = {"prompt", "guarded", "auto"}
 
 
 @dataclass(frozen=True)
@@ -51,6 +51,9 @@ class ExecutionPolicy:
     mode: str
     isolation: str
     policy_version: int = POLICY_VERSION
+    writable_roots: tuple[str, ...] = ()
+    network_access: bool = False
+    approvals_reviewer: str = "user"
 
     def __post_init__(self):
         if self.mode not in VALID_MODES:
@@ -59,11 +62,20 @@ class ExecutionPolicy:
             raise ValueError(f"unknown runtime isolation: {self.isolation}")
 
     def to_record(self) -> dict:
-        return {
+        record = {
             "mode": self.mode,
             "isolation": self.isolation,
             "policy_version": self.policy_version,
         }
+        if self.mode == "guarded":
+            record.update(
+                {
+                    "writable_roots": list(self.writable_roots),
+                    "network_access": self.network_access,
+                    "approvals_reviewer": self.approvals_reviewer,
+                }
+            )
+        return record
 
     @classmethod
     def from_record(cls, value, *, default_isolation: str = "external"):
@@ -71,13 +83,29 @@ class ExecutionPolicy:
         if isinstance(value, cls):
             return value
         if isinstance(value, dict):
+            mode = value.get("mode", "auto")
             return cls(
-                mode=value.get("mode", "auto"),
+                mode=mode,
                 isolation=value.get("isolation", default_isolation),
                 policy_version=int(value.get("policy_version", POLICY_VERSION)),
+                writable_roots=tuple(
+                    str(path) for path in value.get("writable_roots", ())
+                ),
+                network_access=bool(value.get("network_access", mode == "guarded")),
+                approvals_reviewer=str(
+                    value.get(
+                        "approvals_reviewer",
+                        "auto_review" if mode == "guarded" else "user",
+                    )
+                ),
             )
         if isinstance(value, str) and value:
-            return cls(mode=value, isolation=default_isolation)
+            return cls(
+                mode=value,
+                isolation=default_isolation,
+                network_access=value == "guarded",
+                approvals_reviewer="auto_review" if value == "guarded" else "user",
+            )
         return cls(mode="auto", isolation="external")
 
 
@@ -119,8 +147,15 @@ class AutoGrantStore:
             and grant.policy_version == POLICY_VERSION
         )
 
+    @staticmethod
+    def _same_scope(grant: AutoGrant, target: SessionTarget) -> bool:
+        return (
+            grant.wolt_id == target.wolt_id
+            and grant.canonical_workdir == target.canonical_workdir
+        )
+
     def list(self) -> list[AutoGrant]:
-        return self._read()
+        return [grant for grant in self._read() if grant.policy_version == POLICY_VERSION]
 
     def find(self, target: SessionTarget) -> AutoGrant | None:
         return next((g for g in self._read() if self._matches(g, target)), None)
@@ -132,7 +167,7 @@ class AutoGrantStore:
             approved_at=int(time.time()),
         )
         with self._lock():
-            grants = [g for g in self._read() if not self._matches(g, target)]
+            grants = [g for g in self._read() if not self._same_scope(g, target)]
             grants.append(approved)
             self._write(grants)
         return approved
@@ -140,7 +175,7 @@ class AutoGrantStore:
     def revoke(self, target: SessionTarget) -> bool:
         with self._lock():
             grants = self._read()
-            kept = [g for g in grants if not self._matches(g, target)]
+            kept = [g for g in grants if not self._same_scope(g, target)]
             changed = len(kept) != len(grants)
             if changed:
                 self._write(kept)
@@ -151,35 +186,62 @@ def resolve_execution_policy(
     requested: str | None,
     *,
     isolation: str,
+    harness: str = "",
     target: SessionTarget,
     grants: AutoGrantStore,
 ) -> tuple[ExecutionPolicy, AutoGrant | None]:
-    """Resolve defaults and enforce host Auto consent for the exact target.
+    """Resolve harness-aware defaults and enforce host Auto consent.
 
-    On the host the grant *is* the consent, so it also decides the default: a
-    caller that asks for nothing gets Auto exactly where someone has already
-    approved this wolt in this directory, and prompt everywhere else. Without
-    that, every unattended native session — the bot's spawns, the lodge's —
-    booted prompt-mode with nobody there to answer, because no spawn path asks
-    for Auto by name.
+    Native Codex gets a useful unattended default without losing its sandbox:
+    its session workdir is the primary workspace, while the owning wolt home
+    and shared apps directory are additional writable roots. Network is on for
+    normal development and Codex's reviewer handles eligible escalations.
 
-    Explicit still beats implicit in both directions: `requested="prompt"`
-    keeps asking even where Auto is approved, and `requested="auto"` without a
-    grant is refused rather than quietly downgraded.
+    Full Auto remains an explicit override. A standing grant authorizes it but
+    no longer silently selects it; callers must request ``auto`` for the exact
+    wolt/workdir pair. Containers keep their historical externally-sandboxed
+    Auto default.
     """
     grant = grants.find(target) if isolation == "host" else None
-    default = "auto" if isolation == "external" or grant is not None else "prompt"
+    default = default_execution_mode(isolation=isolation, harness=harness)
     mode = requested or default
-    policy = ExecutionPolicy(mode=mode, isolation=isolation)
+    if mode == "guarded" and harness != "codex":
+        raise ValueError("guarded execution policy is supported only by the codex harness")
     if mode == "auto" and isolation == "host" and grant is None:
         raise PermissionError(
             "Auto is not approved for "
             f"wolt '{target.wolt_id}' in '{target.canonical_workdir}'. "
             "Grant that exact wolt and directory before spawning."
         )
-    # A prompt-mode session records no grant: the registry says what the
-    # session actually runs under, not what it could have run under.
+    if mode == "guarded":
+        wolts_dir = grants.wolts_dir.resolve(strict=False)
+        roots = {
+            str((wolts_dir / target.wolt_id).resolve(strict=False)),
+            str((wolts_dir / "apps").resolve(strict=False)),
+        }
+        legacy_apps = wolts_dir / "projects"
+        if legacy_apps.exists():
+            roots.add(str(legacy_apps.resolve(strict=False)))
+        policy = ExecutionPolicy(
+            mode=mode,
+            isolation=isolation,
+            writable_roots=tuple(sorted(roots)),
+            network_access=True,
+            approvals_reviewer="auto_review",
+        )
+    else:
+        policy = ExecutionPolicy(mode=mode, isolation=isolation)
+
+    # The registry says what actually ran, not what a standing grant could
+    # have allowed. Only explicit Full Auto carries the grant on the record.
     return policy, grant if mode == "auto" else None
+
+
+def default_execution_mode(*, isolation: str, harness: str = "") -> str:
+    """Return the no-request default for one runtime and harness."""
+    if isolation == "external":
+        return "auto"
+    return "guarded" if harness == "codex" else "prompt"
 
 
 def policy_mode(value) -> str:

--- a/container/lib/execution_policy.py
+++ b/container/lib/execution_policy.py
@@ -189,6 +189,7 @@ def resolve_execution_policy(
     harness: str = "",
     target: SessionTarget,
     grants: AutoGrantStore,
+    persistent: bool = False,
 ) -> tuple[ExecutionPolicy, AutoGrant | None]:
     """Resolve harness-aware defaults and enforce host Auto consent.
 
@@ -197,17 +198,17 @@ def resolve_execution_policy(
     and shared apps directory are additional writable roots. Network is on for
     normal development and Codex's reviewer handles eligible escalations.
 
-    Full Auto remains an explicit override. A standing grant authorizes it but
-    no longer silently selects it; callers must request ``auto`` for the exact
-    wolt/workdir pair. Containers keep their historical externally-sandboxed
-    Auto default.
+    Full Auto may be a wolt's persistent, self-managed preference. One-off
+    launch overrides remain exact-target grants: a standing grant authorizes
+    Auto but never silently selects it. Containers keep their historical
+    externally-sandboxed Auto default.
     """
     grant = grants.find(target) if isolation == "host" else None
     default = default_execution_mode(isolation=isolation, harness=harness)
     mode = requested or default
     if mode == "guarded" and harness != "codex":
         raise ValueError("guarded execution policy is supported only by the codex harness")
-    if mode == "auto" and isolation == "host" and grant is None:
+    if mode == "auto" and isolation == "host" and grant is None and not persistent:
         raise PermissionError(
             "Auto is not approved for "
             f"wolt '{target.wolt_id}' in '{target.canonical_workdir}'. "
@@ -233,8 +234,9 @@ def resolve_execution_policy(
         policy = ExecutionPolicy(mode=mode, isolation=isolation)
 
     # The registry says what actually ran, not what a standing grant could
-    # have allowed. Only explicit Full Auto carries the grant on the record.
-    return policy, grant if mode == "auto" else None
+    # have allowed. Persistent Auto cites wolt.json by its resolved mode;
+    # one-off Auto also carries its exact grant on the record.
+    return policy, grant if mode == "auto" and not persistent else None
 
 
 def default_execution_mode(*, isolation: str, harness: str = "") -> str:

--- a/container/lib/harnesses.py
+++ b/container/lib/harnesses.py
@@ -28,7 +28,7 @@ from pathlib import Path
 
 from env_compat import get_env
 from session_runtime import RuntimeHandle, get_runtime
-from execution_policy import policy_mode
+from execution_policy import ExecutionPolicy, policy_mode
 from skills_sync import COPY_DELIVERY, PLUGIN_DELIVERY
 
 DEFAULT_HARNESS = "claude"
@@ -76,7 +76,7 @@ def _claude_command(entry: dict, mode: str, *, session_id: str = "",
 def _codex_command(entry: dict, mode: str, *, session_id: str = "",
                    session_name: str = "", model: str = "", prompt: str = "",
                    resume_id: str = "", execution_policy=None) -> str:
-    """Build a Codex CLI command line (verified against codex-cli 0.144).
+    """Build a Codex CLI command line (verified against codex-cli 0.153.4).
 
     Codex can't preset a session id at spawn — run-session.sh discovers the
     rollout id after launch (see discover_session_id). A resume without a
@@ -93,10 +93,26 @@ def _codex_command(entry: dict, mode: str, *, session_id: str = "",
     parts = [wrapper]
     if mode == "resume" and resume_id:
         parts += ["resume", resume_id]
-    # Codex's own help: "Intended solely for running in environments that are
-    # externally sandboxed" — which is exactly the woltspace container.
-    if policy_mode(execution_policy) == "auto":
+    policy = ExecutionPolicy.from_record(execution_policy)
+    # Full Auto remains for externally isolated containers and exact native
+    # grants. Guarded is the native default: the cwd is Codex's primary
+    # workspace, and Woltspace adds only the owning den + shared apps.
+    if policy.mode == "auto":
         parts.append("--dangerously-bypass-approvals-and-sandbox")
+    elif policy.mode == "guarded":
+        parts += [
+            "--sandbox", "workspace-write",
+            "--ask-for-approval", "on-request",
+            "-c", f"approvals_reviewer={policy.approvals_reviewer}",
+            "-c",
+            f"sandbox_workspace_write.network_access={str(policy.network_access).lower()}",
+        ]
+        if policy.writable_roots:
+            parts += [
+                "-c",
+                "sandbox_workspace_write.writable_roots="
+                + json.dumps(list(policy.writable_roots)),
+            ]
     if model:
         parts += ["-m", model]
     if prompt:

--- a/container/lib/sessions.py
+++ b/container/lib/sessions.py
@@ -54,6 +54,7 @@ from session_targets import SessionTarget, normalize_session_target
 from execution_policy import (
     AutoGrantStore,
     ExecutionPolicy,
+    VALID_MODES,
     resolve_execution_policy,
 )
 from runtime_context import RuntimeContext
@@ -1342,6 +1343,9 @@ def start_session(
     app: optional app name — session runs in the shared wolts/apps/{name}/.
     harness: optional harness override (per-session). Falls back to the wolt's
         wolt.json "harness" field, then the platform default (claude).
+    execution_policy: optional per-session override. Falls back to the wolt's
+        wolt.json "execution_policy" field, then the harness-aware platform
+        default.
 
     Returns dict with session info: name, url, wolt, and optionally app/creature/model.
     Raises ValueError if the wolt directory doesn't exist.
@@ -1354,6 +1358,7 @@ def start_session(
     # The wolt.json may also carry a default harness for new sessions.
     wolt_json_path = wolt_home / "wolt" / "wolt.json"
     pinned_model = ""
+    persistent_policy = False
     if wolt_json_path.exists():
         try:
             wolt_data = json.loads(wolt_json_path.read_text())
@@ -1362,6 +1367,20 @@ def start_session(
                 creature = wolt_type
             if not harness:
                 harness = wolt_data.get("harness", "")
+            configured_policy = wolt_data.get("execution_policy")
+            if configured_policy not in (None, ""):
+                if (
+                    not isinstance(configured_policy, str)
+                    or configured_policy not in VALID_MODES
+                ):
+                    raise ValueError(
+                        "unknown execution policy in "
+                        f"{wolt_json_path}: {configured_policy}"
+                    )
+                if execution_policy is None:
+                    execution_policy = configured_policy
+                if execution_policy == configured_policy:
+                    persistent_policy = True
             # per-wolt model pin (validated against the resolved harness below)
             pinned_model = wolt_data.get("model", "") or ""
         except (json.JSONDecodeError, OSError):
@@ -1398,6 +1417,7 @@ def start_session(
         harness=harness,
         target=target,
         grants=AutoGrantStore(WOLTS_DIR),
+        persistent=persistent_policy,
     )
 
     name = session_name(wolt)

--- a/container/lib/sessions.py
+++ b/container/lib/sessions.py
@@ -1339,7 +1339,7 @@ def start_session(
     prompt: opening message for the session.
     creature: optional "raccoon"/"beaver"/"otter" to pick the model.
     routing: adapter routing info (adapter, chat_id, etc.) for notifications.
-    app: optional app name — session runs in wolt/apps/{name}/.
+    app: optional app name — session runs in the shared wolts/apps/{name}/.
     harness: optional harness override (per-session). Falls back to the wolt's
         wolt.json "harness" field, then the platform default (claude).
 
@@ -1374,7 +1374,17 @@ def start_session(
     if app:
         if workdir is not None:
             raise ValueError("workdir cannot be combined with an app session")
-        apps_work_dir = wolt_home / "wolt" / "apps" / app
+        if not re.fullmatch(r"[A-Za-z0-9][A-Za-z0-9_-]*", app):
+            raise ValueError(f"invalid app name: {app}")
+        # Apps are colony-level shipped work, not private wolt state. Keep the
+        # session target aligned with discovery, serving, and the apps skills.
+        primary_app_dir = WOLTS_DIR / "apps" / app
+        legacy_app_dir = WOLTS_DIR / "projects" / app
+        apps_work_dir = (
+            legacy_app_dir
+            if legacy_app_dir.exists() and not primary_app_dir.exists()
+            else primary_app_dir
+        )
         apps_work_dir.mkdir(parents=True, exist_ok=True)
         workdir = apps_work_dir
 
@@ -1385,6 +1395,7 @@ def start_session(
     policy, grant = resolve_execution_policy(
         execution_policy,
         isolation=isolation,
+        harness=harness,
         target=target,
         grants=AutoGrantStore(WOLTS_DIR),
     )

--- a/container/lib/wolts.py
+++ b/container/lib/wolts.py
@@ -302,7 +302,7 @@ identity, memory, and site. The platform provides shared infrastructure; you pro
 
 ## Rules
 
-- **DO NOT edit files outside your wolt directory** — no touching `/workspace/woltspace/`, other wolts, or system files
+- **Edit only your wolt home, the session's explicit workdir, and user-approved shared apps** — no touching the Woltspace platform, other wolt homes, `.space`, or system files
 - **DO NOT restart the woltspace server** (FastAPI, port 7777) — it runs the tunnel, viewport, and session routing
 - **DO NOT modify `woltspace-*` skills** in `.claude/skills/` — they are synced from the platform on every boot and will be overwritten
 - **DO NOT use built-in Claude Code memory** — write to `wolt/memory/` instead
@@ -323,6 +323,7 @@ Edit files and changes appear instantly. Use `push-view` to show a specific page
 ## Apps
 
 Apps live in `wolts/apps/` and have their own server and dependencies.
+They are shared colony work: edit one only when the user places that app in scope.
 Don't create apps without user permission — load the woltspace new-app skill when ready.
 """
 

--- a/container/skills/start-chat/SKILL.md
+++ b/container/skills/start-chat/SKILL.md
@@ -34,10 +34,11 @@ Do NOT summarize what you read. Just absorb the context and be ready to work.
 
 **NEVER restart, kill, or modify the woltspace server (FastAPI, port 7777)** — it runs the tunnel, split view, and all session routing. Restarting it breaks everything for everyone. If something seems wrong with the server, notify the developer and stop.
 
-**You can ONLY edit files inside your wolt directory.** Never edit, create, or delete files in:
+**Only edit files in the session's authorized workspaces:** your own wolt directory, the session's explicit work directory, and a shared app the user has put in scope. Never edit, create, or delete files in:
 - `/workspace/woltspace/` — this is the platform code. Editing it breaks updates.
-- Other wolts' directories
-- System files outside your wolt
+- Other wolts' home directories
+- Woltspace's private `.space/` state
+- System files outside the authorized workspaces
 
 **Your site (`wolt/site/`) is your private workspace.** Use it freely — static HTML/CSS/JS, scratch pages, personal dashboards, anything lightweight. It's always live in the viewport with livereload. This is your desk.
 

--- a/docs/native-and-container.md
+++ b/docs/native-and-container.md
@@ -6,9 +6,9 @@ implementations of it — they are two answers to a single question:
 > **Whose machine takes the risk when a wolt runs a command?**
 
 - **Native** — the control plane runs on your machine, in your shell, with the
-  harness you already logged into. A wolt working in one of your repos touches
-  your files, so it asks before it acts. Nothing copies your credentials
-  anywhere.
+  harness you already logged into. Codex defaults to a workspace sandbox with
+  automatic approval review; other harnesses keep their normal prompt mode.
+  Nothing copies your credentials anywhere.
 - **Container** — Docker is *Auto wolts in a box*. The wolt can run without
   asking because the blast radius is a disposable container and one mounted
   directory.
@@ -19,7 +19,7 @@ is the same code either way. Choose by how much you want to be asked.
 | | Native | Container |
 |---|---|---|
 | Harness auth | your own, reused in place | seeded into the image |
-| Default permission | prompt, auto where you granted it | auto (opt-in per wolt) |
+| Default permission | Codex guarded; other harnesses prompt | auto inside the external sandbox |
 | Session working dir | any repo on your machine | the mounted wolts directory |
 | Survives a platform update | yes — tmux outlives the control plane | container rebuild ends sessions |
 | Public URL | tunnel **off** by default | tunnel on by default |
@@ -34,7 +34,7 @@ uv tool install 'woltspace[connectors]'
 woltspace start          # runs doctor, takes the data-root lock, serves the lodge
 woltspace tui            # the terminal UI
 woltspace status         # who owns the data root, which sessions were adopted
-woltspace auto list      # which wolts may work unattended, and where
+woltspace auto list      # which exact targets may explicitly use Full Auto
 woltspace stop           # stops the control plane — never touches tmux
 ```
 
@@ -51,14 +51,40 @@ The `connectors` extra brings the Telegram dependencies. Without it the
 Telegram connector reports itself disabled with that remedy instead of
 crash-looping.
 
-### Auto — letting a wolt work unattended
+### Guarded — native Codex without the prompt treadmill
 
-A native session asks before it acts. That is the right default for a machine
-with your repos on it, but it also means nobody is home: a wolt woken by
-Telegram, or by the wolf at 6am, stops at the first permission prompt and waits
-for a human who is asleep.
+Every native Codex session defaults to **Guarded**. Woltspace launches Codex in
+`workspace-write` mode with network access and `approvals_reviewer=auto_review`,
+so ordinary development continues without waiting for a human while Codex's
+reviewer evaluates actions that need escalation. Review failures and timeouts
+fail closed; Guarded is not the same thing as bypassing the sandbox. Reviewed
+escalations use additional model calls.
 
-**Auto** is the other posture, and it is granted per wolt *and* per directory:
+The writable set is derived for every session instead of being saved in the
+user's global Codex config:
+
+- the exact session workdir is Codex's primary workspace;
+- the owning wolt home is an additional root, so identity and memory survive
+  even when the session works in another repository;
+- `<wolts>/apps` is an additional shared root, because apps are colony-level
+  shipped work rather than one wolt's private memory;
+- legacy `<wolts>/projects` is included only while that migrated directory
+  still exists.
+
+The whole `<wolts>` directory is deliberately not writable. A wolt does not
+gain sibling wolt homes or `<wolts>/.space` merely because it can work on shared
+apps. An app-scoped session runs in the canonical `<wolts>/apps/<name>` path;
+this is the same path app discovery, serving, and the apps skills use.
+
+Claude and opencode remain in prompt mode on a native host because Woltspace
+does not pretend their permission systems provide Codex's Auto-review contract.
+Containers retain full Auto because Docker is their external boundary.
+
+### Full Auto — explicit, exact, and exceptional
+
+Full Auto removes the Codex sandbox. Native Woltspace therefore requires a
+standing grant for one wolt *and* one exact directory before a caller may
+explicitly request it:
 
 ```bash
 woltspace auto grant mossy                 # its own wolt directory
@@ -68,25 +94,29 @@ woltspace auto revoke mossy --workdir ~/src/api
 ```
 
 A grant names one wolt and one canonical directory — symlinks resolved, so the
-path recorded is the path a session actually runs in. It is not a mode you
-switch on; it is consent you gave to a specific pair, and it is the whole of the
-consent: **once a grant exists, sessions for that wolt in that directory
-default to Auto**, and everything else keeps asking. That is what makes an
-unattended wolt possible without a flag on every spawn — nothing in the lodge,
-the bot, or the wolf asks for Auto by name.
+path recorded is the path a session actually runs in. The grant authorizes
+Full Auto but does not silently select it: an omitted policy still resolves to
+Guarded for Codex. This keeps an old consent record from turning a routine wake
+into an unrestricted host process.
 
-The explicit forms still win in both directions. A session started in prompt
-mode on purpose keeps asking even where Auto is approved, and asking for Auto
-where no grant exists is refused rather than quietly downgraded — you find out
-at spawn, not three commands into the transcript.
+After granting, request the override on the spawn itself:
+
+```bash
+woltspace session spawn mossy "work unattended" --auto
+```
+
+An explicit prompt-mode session still asks, and an explicit Auto request with
+no matching grant is refused rather than quietly downgraded — you find out at
+spawn, not three commands into the transcript.
 
 Grants live in `<wolts>/.space/auto-grants.json`, owner-readable only, and
-`woltspace auto revoke` takes one back. Revoking does not touch a session
-already running under it: a live agent keeps the permissions it started with
-until it exits.
+`woltspace auto revoke` takes one back. Policy version 2 invalidates the old
+implicit-Auto grants; re-grant only the exact targets that should retain Full
+Auto. Changing a grant does not touch a live process: every session keeps the
+permissions it started with until it exits.
 
 Containers do not use grants. Their whole isolation argument is the disposable
-box, so Auto is their default and the grant store is ignored.
+box, so Auto remains their default and the grant store is ignored.
 
 > Two programs answer to `woltspace auto` — see the shadowing note further
 > down. The native CLI's `auto` reads and writes the grant file directly, so it

--- a/docs/native-and-container.md
+++ b/docs/native-and-container.md
@@ -80,11 +80,34 @@ Claude and opencode remain in prompt mode on a native host because Woltspace
 does not pretend their permission systems provide Codex's Auto-review contract.
 Containers retain full Auto because Docker is their external boundary.
 
-### Full Auto — explicit, exact, and exceptional
+### Per-wolt permission settings
+
+The Settings page exposes the policy used whenever each wolt wakes. It writes
+the preference alongside that wolt's other self-managed configuration:
+
+```json
+{
+  "harness": "codex",
+  "execution_policy": "auto"
+}
+```
+
+The supported values are `prompt`, `guarded`, and `auto`. Omitting the field
+means “follow the harness default”: Guarded for native Codex, prompt for the
+other native harnesses, and Auto in an externally isolated container. An
+explicit policy passed for one spawn wins over the saved preference.
+
+This is intentionally the same ownership model as the per-wolt `harness`
+field: a wolt may update its own setting, and the next session honors it.
+Selecting Full Auto in Settings warns before saving; changing away from it
+takes effect on the next wake. A running process always keeps the policy it
+started with.
+
+### One-off Full Auto — explicit, exact, and exceptional
 
 Full Auto removes the Codex sandbox. Native Woltspace therefore requires a
 standing grant for one wolt *and* one exact directory before a caller may
-explicitly request it:
+explicitly request it without changing the wolt's durable setting:
 
 ```bash
 woltspace auto grant mossy                 # its own wolt directory
@@ -94,10 +117,9 @@ woltspace auto revoke mossy --workdir ~/src/api
 ```
 
 A grant names one wolt and one canonical directory — symlinks resolved, so the
-path recorded is the path a session actually runs in. The grant authorizes
-Full Auto but does not silently select it: an omitted policy still resolves to
-Guarded for Codex. This keeps an old consent record from turning a routine wake
-into an unrestricted host process.
+path recorded is the path a session actually runs in. The grant authorizes a
+one-off Full Auto request but does not silently select it or change
+`wolt.json`. This keeps an old consent record from changing routine wakes.
 
 After granting, request the override on the spawn itself:
 
@@ -105,9 +127,10 @@ After granting, request the override on the spawn itself:
 woltspace session spawn mossy "work unattended" --auto
 ```
 
-An explicit prompt-mode session still asks, and an explicit Auto request with
-no matching grant is refused rather than quietly downgraded — you find out at
-spawn, not three commands into the transcript.
+An explicit prompt-mode session still asks. If the wolt has no persistent
+`auto` preference, an explicit Auto request with no matching grant is refused
+rather than quietly downgraded — you find out at spawn, not three commands
+into the transcript.
 
 Grants live in `<wolts>/.space/auto-grants.json`, owner-readable only, and
 `woltspace auto revoke` takes one back. Policy version 2 invalidates the old

--- a/docs/native-first-run.md
+++ b/docs/native-first-run.md
@@ -225,6 +225,8 @@ the lodge and the split view opens with a terminal on the left. Native Codex
 wolts start in Guarded mode: their own home, shared apps, network access, and
 automatic approval review are ready without a blocking permission prompt.
 Claude and opencode wolts retain their ordinary interactive permission flow.
+The Settings page can pin `prompt`, `guarded`, or Full Auto for an individual
+wolt; the choice is saved in its `wolt.json` and applies to future sessions.
 
 ---
 

--- a/docs/native-first-run.md
+++ b/docs/native-first-run.md
@@ -221,11 +221,10 @@ The tunnel is **off** by default natively; nothing is published. To expose the
 lodge deliberately, `WOLTSPACE_PUBLIC_TUNNEL=true woltspace start`.
 
 Open <http://127.0.0.1:7777> and the lodge should be there. Create a wolt from
-the lodge and the split view opens with a terminal on the left. The first
-thing you will see in it is Claude Code's own **workspace trust prompt** for
-the new wolt directory — native sessions run bare `claude` (the container
-pre-trusts with `wclaude`), and prompt mode is the point. Accept it and the
-session continues; it has not hung.
+the lodge and the split view opens with a terminal on the left. Native Codex
+wolts start in Guarded mode: their own home, shared apps, network access, and
+automatic approval review are ready without a blocking permission prompt.
+Claude and opencode wolts retain their ordinary interactive permission flow.
 
 ---
 

--- a/docs/switching-models.md
+++ b/docs/switching-models.md
@@ -1,9 +1,9 @@
-# Switching a wolt's engine and model
+# Switching a wolt's engine, model, and permissions
 
-A wolt runs on a **harness** (the engine — Claude Code, Codex, …) and a **model**
-(the specific model that engine uses). Both are chosen when a session spawns and are
-**frozen for that session's life** — switching changes the *next* session, never a
-running one.
+A wolt runs on a **harness** (the engine — Claude Code, Codex, …), a **model**
+(the specific model that engine uses), and an **execution policy**. All three
+are chosen when a session spawns and are **frozen for that session's life** —
+switching changes the *next* session, never a running one.
 
 This is a per-wolt setting: change it and every new session for that wolt picks it up.
 
@@ -15,7 +15,8 @@ Edit the wolt's `wolt/wolt.json`:
 {
   "type": "raccoon",        // the creature tier — lore/identity, do not change to switch models
   "harness": "codex",       // OPTIONAL engine override; omit to follow the lodge default
-  "model": "gpt-5.6-sol"    // OPTIONAL model pin; omit to use the tier's default model
+  "model": "gpt-5.6-sol",   // OPTIONAL model pin; omit to use the tier's default model
+  "execution_policy": "auto" // OPTIONAL permission pin; omit to follow the harness default
 }
 ```
 
@@ -23,6 +24,10 @@ Edit the wolt's `wolt/wolt.json`:
   field entirely to follow the lodge-wide default.
 - **Change the model** — set `"model"` to a valid id for that engine. Omit it to fall back
   to the engine's default model for the wolt's tier.
+- **Change permissions** — set `"execution_policy"` to `prompt`, `guarded`, or
+  `auto`. Guarded is available only for Codex. Omit it to use the harness-aware
+  default: Guarded for native Codex, prompt for other native harnesses, and
+  Auto in a container.
 
 The change takes effect on the wolt's **next** session. A wolt can do this to itself, or
 do it on a user's behalf — it's just a config edit.

--- a/public/static/settings.js
+++ b/public/static/settings.js
@@ -12,6 +12,7 @@ if (root) {
       input.closest('.ds-choice-card').querySelector('.ds-choice-title').textContent.trim(),
     ]),
   );
+  const policyDefaults = JSON.parse(root.dataset.policyDefaults || '{}');
   let toastTimer;
 
   function setGlobalState(kind, message) {
@@ -44,6 +45,25 @@ if (root) {
     document.querySelectorAll('[data-wolt-status][data-following="true"]').forEach(status => {
       status.textContent = `Follows lodge · ${defaultHarness}`;
     });
+  }
+
+  function refreshPolicyHarness(wolt, harness) {
+    const row = document.querySelector(
+      `[data-wolt-policy-row][data-wolt="${CSS.escape(wolt)}"]`,
+    );
+    if (!row) return;
+    const select = row.querySelector('[data-policy-select]');
+    const status = row.querySelector('[data-policy-status]');
+    const defaultOption = select.querySelector('[data-default-option]');
+    const guardedOption = select.querySelector('[value="guarded"]');
+    const defaultPolicy = policyDefaults[harness] || 'prompt';
+    row.dataset.harness = harness;
+    row.dataset.defaultPolicy = defaultPolicy;
+    defaultOption.textContent = `Follow ${harness} default · ${defaultPolicy}`;
+    guardedOption.disabled = harness !== 'codex' && select.value !== 'guarded';
+    if (!select.value) {
+      status.textContent = `Follows ${harness} default · ${defaultPolicy}`;
+    }
   }
 
   document.querySelector('[data-default-form]')?.addEventListener('change', async event => {
@@ -83,8 +103,45 @@ if (root) {
         row.dataset.savedValue = requested || '';
         status.dataset.following = String(!data.pinned);
         status.textContent = data.pinned ? `Pinned · ${data.harness}` : `Follows lodge · ${data.harness}`;
+        refreshPolicyHarness(row.dataset.wolt, data.harness);
         setGlobalState('saved', `${row.dataset.wolt} saved`);
         showToast(`${row.dataset.wolt} will use ${harnessLabels.get(data.harness) || data.harness}.`);
+      } catch (error) {
+        select.value = previous;
+        setGlobalState('error', 'Could not save');
+        showToast(error.message, 'error');
+      } finally {
+        select.disabled = false;
+      }
+    });
+  });
+
+  document.querySelectorAll('[data-policy-select]').forEach(select => {
+    select.addEventListener('change', async () => {
+      const row = select.closest('[data-wolt-policy-row]');
+      const status = row.querySelector('[data-policy-status]');
+      const previous = row.dataset.savedValue;
+      const requested = select.value || null;
+      if (requested === 'auto' && !window.confirm(
+        `Give ${row.dataset.wolt} Full Auto on future sessions? This removes approval prompts and the agent sandbox.`,
+      )) {
+        select.value = previous;
+        return;
+      }
+      select.disabled = true;
+      setGlobalState('saving', `Saving ${row.dataset.wolt} permissions…`);
+      try {
+        const data = await save(
+          `/wolts/${encodeURIComponent(row.dataset.wolt)}/execution-policy`,
+          { execution_policy: requested },
+        );
+        row.dataset.savedValue = requested || '';
+        status.dataset.following = String(!data.pinned);
+        status.textContent = data.pinned
+          ? `Pinned · ${data.execution_policy}`
+          : `Follows ${row.dataset.harness} default · ${data.execution_policy}`;
+        setGlobalState('saved', `${row.dataset.wolt} saved`);
+        showToast(`${row.dataset.wolt} will use ${data.execution_policy} on future sessions.`);
       } catch (error) {
         select.value = previous;
         setGlobalState('error', 'Could not save');

--- a/server/app.py
+++ b/server/app.py
@@ -63,7 +63,7 @@ from sessions import (
 )
 from session_runtime import RuntimeHandle, get_runtime
 from session_targets import SessionTarget
-from execution_policy import AutoGrantStore, POLICY_VERSION
+from execution_policy import AutoGrantStore, POLICY_VERSION, default_execution_mode
 from runtime_context import RuntimeContext
 from harness_auth import auth_source, claude_authenticated
 from skills_sync import wolt_skills_delivery
@@ -1163,12 +1163,19 @@ async def set_wolt_harness(name: str, request: Request):
 @app.get("/runtime/capabilities")
 async def runtime_capabilities():
     context = RuntimeContext.from_env()
+    default_harness = get_default_harness()
+    policies = {
+        harness: default_execution_mode(
+            isolation=context.isolation, harness=harness
+        )
+        for harness in HARNESSES
+    }
     return {
         "isolation": context.isolation,
         "supports_host_workdirs": context.isolation == "host",
-        "default_execution_policy": (
-            "prompt" if context.isolation == "host" else "auto"
-        ),
+        "default_harness": default_harness,
+        "default_execution_policy": policies[default_harness],
+        "default_execution_policies": policies,
         "policy_version": POLICY_VERSION,
     }
 

--- a/server/app.py
+++ b/server/app.py
@@ -63,7 +63,12 @@ from sessions import (
 )
 from session_runtime import RuntimeHandle, get_runtime
 from session_targets import SessionTarget
-from execution_policy import AutoGrantStore, POLICY_VERSION, default_execution_mode
+from execution_policy import (
+    AutoGrantStore,
+    POLICY_VERSION,
+    VALID_MODES,
+    default_execution_mode,
+)
 from runtime_context import RuntimeContext
 from harness_auth import auth_source, claude_authenticated
 from skills_sync import wolt_skills_delivery
@@ -1118,6 +1123,20 @@ async def set_harness_default(request: Request):
     name = (body.get("harness") or "").strip()
     if name not in HARNESSES:
         return JSONResponse({"error": f"unknown harness: {name}"}, status_code=400)
+    if name != "codex":
+        blocked = [
+            wolt.get("name") or wolt.get("dir")
+            for wolt in _configured_wolts()
+            if not wolt.get("harness") and wolt.get("execution_policy") == "guarded"
+        ]
+        if blocked:
+            return JSONResponse(
+                {
+                    "error": "Guarded is Codex-only; change the execution policy "
+                    "for these wolts first: " + ", ".join(blocked)
+                },
+                status_code=409,
+            )
     set_default_harness(name)
     return {"ok": True, "default": name}
 
@@ -1152,10 +1171,85 @@ async def set_wolt_harness(name: str, request: Request):
     else:
         return JSONResponse({"error": f"unknown harness: {requested}"}, status_code=400)
 
+    if cfg.get("execution_policy") == "guarded" and effective != "codex":
+        return JSONResponse(
+            {"error": "Guarded execution is available only for Codex wolts"},
+            status_code=409,
+        )
+
     tmp = wolt_json.with_suffix(".tmp")
     tmp.write_text(json.dumps(cfg, indent=2) + "\n")
     tmp.rename(wolt_json)
     return {"ok": True, "wolt": safe, "harness": effective, "pinned": pinned}
+
+
+@app.post("/wolts/{name}/execution-policy")
+async def set_wolt_execution_policy(name: str, request: Request):
+    """Pin or clear a wolt's policy for every future session.
+
+    The preference lives in wolt.json and is itself authoritative, like the
+    existing per-wolt harness setting. Exact-target grants remain available
+    for one-off Auto launches that do not change this durable preference.
+    """
+    body = await request.json()
+    requested = body.get("execution_policy")
+
+    safe = "".join(c for c in name if c.isalnum() or c in "-_")
+    wolt_json = WOLTS_DIR / safe / "wolt" / "wolt.json"
+    if not wolt_json.exists():
+        return JSONResponse({"error": f"wolt not found: {safe}"}, status_code=404)
+
+    try:
+        cfg = json.loads(wolt_json.read_text())
+    except (json.JSONDecodeError, OSError):
+        return JSONResponse({"error": "wolt.json unreadable"}, status_code=500)
+
+    if requested in (None, ""):
+        selected = None
+    elif isinstance(requested, str) and requested in VALID_MODES:
+        selected = requested
+    else:
+        return JSONResponse(
+            {"error": f"unknown execution policy: {requested}"}, status_code=400
+        )
+
+    effective_harness = resolve_harness(cfg.get("harness") or get_default_harness())
+    if selected == "guarded" and effective_harness != "codex":
+        return JSONResponse(
+            {"error": "Guarded execution is available only for Codex wolts"},
+            status_code=409,
+        )
+
+    try:
+        target = SessionTarget.resolve(safe, None, wolts_dir=WOLTS_DIR)
+    except ValueError as exc:
+        return JSONResponse({"error": str(exc)}, status_code=400)
+    if selected is None:
+        cfg.pop("execution_policy", None)
+    else:
+        cfg["execution_policy"] = selected
+
+    tmp = wolt_json.with_suffix(".tmp")
+    tmp.write_text(json.dumps(cfg, indent=2) + "\n")
+    tmp.rename(wolt_json)
+
+    # Moving away from persistent Auto also withdraws any old one-off grant
+    # for the wolt's default home. Grants for explicit app/repository targets
+    # remain independently scoped.
+    if selected != "auto":
+        AutoGrantStore(WOLTS_DIR).revoke(target)
+
+    default = default_execution_mode(
+        isolation=RuntimeContext.from_env().isolation,
+        harness=effective_harness,
+    )
+    return {
+        "ok": True,
+        "wolt": safe,
+        "execution_policy": selected or default,
+        "pinned": selected is not None,
+        "source": "wolt.json" if selected is not None else "harness_default",
+    }
 
 
 # --- Runtime capabilities and repository-scoped Auto consent ---
@@ -1764,11 +1858,17 @@ async def settings_page(request: Request):
         wolt for wolt in _configured_wolts()
         if wolt.get("type", "rodent") in configurable_types
     ]
+    isolation = RuntimeContext.from_env().isolation
+    execution_policy_defaults = {
+        harness: default_execution_mode(isolation=isolation, harness=harness)
+        for harness in HARNESSES
+    }
     return templates.TemplateResponse(request, "settings.html", context={
         "active_nav": "settings",
         "cache_bust": int(time.time()),
         "harness_default": get_default_harness(),
         "harnesses": harness_metadata(),
+        "execution_policy_defaults": execution_policy_defaults,
         "wolts": wolts,
     })
 

--- a/src/woltspace/cli.py
+++ b/src/woltspace/cli.py
@@ -521,7 +521,7 @@ def _auto_grant(args) -> int:
         print(json.dumps({"ok": True, "grant": grant.to_record()}, indent=2))
         return 0
     lore.headline(lore.SUN, f"auto approved: {target.wolt_id}")
-    lore.subtitle("it works here without asking")
+    lore.subtitle("Full Auto may be requested here")
     lore.labelled("workdir", str(target.canonical_workdir))
     return 0
 
@@ -542,7 +542,7 @@ def _auto_revoke(args) -> int:
         lore.MOON,
         f"auto {'revoked' if revoked else 'was not granted'}: {target.wolt_id}",
     )
-    lore.subtitle("it asks again from here on")
+    lore.subtitle("Full Auto is unavailable here")
     lore.labelled("workdir", str(target.canonical_workdir))
     return 0
 
@@ -557,10 +557,10 @@ def _auto_list(args) -> int:
         return 0
     if not grants:
         lore.headline(lore.TRACKS, "no auto grants")
-        lore.subtitle("every native session asks before it acts")
+        lore.subtitle("native Codex still uses the Guarded default")
         return 0
     lore.headline(lore.TRACKS, f"auto grants: {len(grants)}")
-    lore.subtitle("these wolts work unattended in these directories")
+    lore.subtitle("these exact targets may explicitly request Full Auto")
     for grant in grants:
         lore.labelled(grant.wolt_id, str(grant.canonical_workdir))
     return 0
@@ -645,7 +645,7 @@ def build_parser() -> argparse.ArgumentParser:
     auto_sub = auto.add_subparsers(dest="verb")
 
     auto_grant = auto_sub.add_parser(
-        "grant", help="let a wolt work unattended in one exact directory"
+        "grant", help="allow explicit Full Auto in one exact directory"
     )
     auto_grant.add_argument("wolt")
     auto_grant.add_argument(

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -6,7 +6,7 @@ identity, memory, and site. The platform provides shared infrastructure; you pro
 
 ## Rules
 
-- **DO NOT edit files outside your wolt directory** — no touching `/workspace/woltspace/`, other wolts, or system files
+- **Edit only your wolt home, the session's explicit workdir, and user-approved shared apps** — no touching the Woltspace platform, other wolt homes, `.space`, or system files
 - **DO NOT restart the woltspace server** (FastAPI, port 7777) — it runs the tunnel, viewport, and session routing
 - **DO NOT modify `woltspace-*` skills** in `.claude/skills/` — they are synced from the platform on every boot and will be overwritten
 - **DO NOT use built-in Claude Code memory** — write to `wolt/memory/` instead
@@ -27,6 +27,7 @@ Edit files and changes appear instantly. Use `push-view` to show a specific page
 ## Apps
 
 Apps live in `wolts/apps/` and have their own server and dependencies.
+They are shared colony work: edit one only when the user places that app in scope.
 Don't create apps without user permission — load the woltspace new-app skill when ready.
 <!-- WOLTSPACE:END -->
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -4,7 +4,10 @@
 {% block title %}Settings · Woltspace{% endblock %}
 
 {% block content %}
-<div class="ds-page settings-page" data-settings-root data-default-harness="{{ harness_default }}">
+<div class="ds-page settings-page"
+     data-settings-root
+     data-default-harness="{{ harness_default }}"
+     data-policy-defaults='{{ execution_policy_defaults | tojson }}'>
   {% call page_header('Lodge controls', 'Settings', 'Shape how the lodge behaves without reaching for a config file.') %}
     <span class="ds-save-state" data-global-state role="status" aria-live="polite">
       <span class="ds-save-dot"></span><span data-global-message>Changes save here</span>
@@ -15,6 +18,7 @@
     <nav class="settings-index" aria-label="Settings sections">
       <p class="settings-index-label">Configuration</p>
       {{ tab_link('#agent-engines', 'Agent engines', 'defaults + overrides', active=true) }}
+      {{ tab_link('#session-permissions', 'Session permissions', 'per-wolt defaults') }}
       {{ tab_link('', 'Notifications', 'coming down the trail', disabled=true) }}
       {{ tab_link('', 'Desktop', 'after the Mac build', disabled=true) }}
     </nav>
@@ -70,6 +74,49 @@
           {{ empty_state('🪵', 'No wolts to configure yet', 'Create a wolt and it will settle in here.') }}
         {% endif %}
       {% endcall %}
+
+      <div id="session-permissions">
+        {% call panel('Session permissions', 'Choose what each wolt uses on every future wake.', (wolts|length ~ ' wolts')) %}
+          {% if wolts %}
+            <div class="ds-field-list">
+              {% for wolt in wolts %}
+                {% set wolt_name = wolt.name or wolt.dir %}
+                {% set wolt_type = wolt.type or 'rodent' %}
+                {% set selected = wolt.execution_policy or '' %}
+                {% set effective_harness = wolt.harness or harness_default %}
+                {% set default_policy = execution_policy_defaults.get(effective_harness, execution_policy_defaults[harness_default]) %}
+                {% set effective = selected or default_policy %}
+                {% set field_id = 'wolt-policy-' ~ loop.index %}
+                {% call select_field(field_id, wolt_name, wolt_type ~ ' · ' ~ effective_harness) %}
+                  <div class="ds-select-stack"
+                       data-wolt-policy-row
+                       data-wolt="{{ wolt.dir or wolt_name }}"
+                       data-harness="{{ effective_harness }}"
+                       data-default-policy="{{ default_policy }}"
+                       data-saved-value="{{ selected }}">
+                    <select class="ds-select" id="{{ field_id }}" aria-describedby="{{ field_id }}-help" data-policy-select>
+                      <option value="" data-default-option{% if not selected %} selected{% endif %}>Follow {{ effective_harness }} default · {{ default_policy }}</option>
+                      <option value="prompt"{% if selected == 'prompt' %} selected{% endif %}>Prompt for approval</option>
+                      <option value="guarded"{% if selected == 'guarded' %} selected{% endif %}{% if effective_harness != 'codex' and selected != 'guarded' %} disabled{% endif %}>Guarded auto-review · Codex</option>
+                      <option value="auto"{% if selected == 'auto' %} selected{% endif %}>Full Auto · YOLO</option>
+                    </select>
+                    <span class="ds-pill ds-pill-subtle" data-policy-status data-following="{{ 'true' if not selected else 'false' }}">
+                      {{ ('Follows ' ~ effective_harness ~ ' default') if not selected else 'Pinned' }} · {{ effective }}
+                    </span>
+                  </div>
+                {% endcall %}
+              {% endfor %}
+            </div>
+          {% else %}
+            {{ empty_state('🪵', 'No wolts to configure yet', 'Create a wolt and it will settle in here.') }}
+          {% endif %}
+        {% endcall %}
+      </div>
+
+      <div class="ds-callout" role="note">
+        <span class="ds-callout-icon" aria-hidden="true">⚠️</span>
+        <div><strong>Full Auto means full runtime access</strong><p>The wolt can run commands without approval or an agent sandbox. The setting persists in its wolt.json until changed here or by the wolt.</p></div>
+      </div>
     </div>
   </div>
 </div>

--- a/test/test_apps.py
+++ b/test/test_apps.py
@@ -517,10 +517,9 @@ class TestE2EAppLifecycle:
         assert app["url"] == "/app/e2e-test-app/"
 
     def test_app_session_scoping_creates_dir(self, shadow_wolt):
-        """start_session with app= creates the app directory under the wolt."""
+        """start_session with app= targets the colony's shared apps directory."""
         wolt_name = shadow_wolt
-        wolt_dir = self.WOLTS_DIR / wolt_name
-        test_app = wolt_dir / "wolt" / "apps" / "e2e-auto-created"
+        test_app = self.WOLTS_DIR / "apps" / "e2e-auto-created"
         try:
             if test_app.exists():
                 import shutil

--- a/test/test_auto_grants_cli.py
+++ b/test/test_auto_grants_cli.py
@@ -1,8 +1,7 @@
-"""`woltspace auto` — issuing the consent that makes native Auto reachable.
+"""`woltspace auto` — issuing the consent that makes native Full Auto reachable.
 
-The grant is the only thing standing between a native wolt and unattended
-work, and until this command existed nothing on a host could issue one without
-a running control plane to POST to. So these tests care about two things:
+The grant is the only thing standing between a native wolt and explicit Full
+Auto. Guarded mode does not consume it. These tests care about two things:
 
 * the CLI writes the *same* grant the runtime reads — same store, same
   canonicalization, no second answer to "is this directory approved?";
@@ -25,7 +24,11 @@ ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "src"))
 sys.path.insert(0, str(ROOT / "container" / "lib"))
 
-from execution_policy import AutoGrantStore, resolve_execution_policy  # noqa: E402
+from execution_policy import (  # noqa: E402
+    AutoGrantStore,
+    POLICY_VERSION,
+    resolve_execution_policy,
+)
 from session_targets import SessionTarget  # noqa: E402
 from woltspace.cli import main as cli_main  # noqa: E402
 
@@ -78,27 +81,33 @@ class TestGrant:
         # And nothing else. Consent is per directory, not per wolt.
         assert _store(colony).find(_target(colony)) is None
 
-    def test_the_grant_is_the_one_a_spawn_actually_reads(self, colony, tmp_path):
-        """The point of the whole feature: after this, a host session that
-        asks for no particular policy runs Auto instead of waiting for a human
-        who is not there."""
+    def test_the_grant_is_the_one_an_explicit_auto_spawn_reads(
+        self, colony, tmp_path
+    ):
+        """A grant authorizes Full Auto without silently making it the default."""
         repo = tmp_path / "repo"
         repo.mkdir()
         target = _target(colony, repo)
         store = _store(colony)
 
         before, _ = resolve_execution_policy(
-            None, isolation="host", target=target, grants=store
+            None, isolation="host", harness="codex", target=target, grants=store
         )
-        assert before.mode == "prompt"
+        assert before.mode == "guarded"
 
         assert cli_main(["auto", "grant", "testwolt", "--workdir", str(repo)]) == 0
 
         after, grant = resolve_execution_policy(
-            None, isolation="host", target=target, grants=store
+            "auto", isolation="host", harness="codex", target=target, grants=store
         )
         assert after.mode == "auto"
         assert grant is not None
+
+        default_after_grant, default_grant = resolve_execution_policy(
+            None, isolation="host", harness="codex", target=target, grants=store
+        )
+        assert default_after_grant.mode == "guarded"
+        assert default_grant is None
 
     def test_granting_twice_leaves_one_grant(self, colony):
         cli_main(["auto", "grant", "testwolt"])
@@ -167,7 +176,7 @@ class TestList:
         assert cli_main(["auto", "list"]) == 0
         out = capsys.readouterr().out
         assert "no auto grants" in out
-        assert "asks before it acts" in out
+        assert "Guarded default" in out
 
     def test_the_listed_lines_carry_both_facts(self, colony, tmp_path, capsys):
         repo = tmp_path / "repo"
@@ -189,7 +198,7 @@ class TestList:
         grants = json.loads(capsys.readouterr().out)["grants"]
 
         assert [g["wolt_id"] for g in grants] == ["testwolt"]
-        assert grants[0]["policy_version"] == 1
+        assert grants[0]["policy_version"] == POLICY_VERSION
 
     def test_listing_never_creates_the_colony_it_was_pointed_at(
         self, tmp_path, monkeypatch, capsys

--- a/test/test_execution_policy.py
+++ b/test/test_execution_policy.py
@@ -34,32 +34,63 @@ def test_external_isolation_defaults_to_auto(tmp_path):
     assert grant is None
 
 
-def test_host_defaults_to_prompt_without_a_grant(tmp_path):
+def test_host_claude_defaults_to_prompt_without_a_grant(tmp_path):
     target, wolts = _target(tmp_path)
     policy, grant = resolve_execution_policy(
-        None, isolation="host", target=target, grants=AutoGrantStore(wolts)
+        None, isolation="host", harness="claude",
+        target=target, grants=AutoGrantStore(wolts)
     )
     assert policy == ExecutionPolicy(mode="prompt", isolation="host")
     assert grant is None
 
 
-def test_host_defaults_to_auto_where_the_grant_already_says_so(tmp_path):
-    """The grant *is* the consent, so it decides the default too.
+def test_host_codex_defaults_to_guarded_with_wolt_and_apps_roots(tmp_path):
+    target, wolts = _target(tmp_path)
+    (wolts / "apps").mkdir()
+    (wolts / "otherwolt").mkdir()
+    policy, grant = resolve_execution_policy(
+        None, isolation="host", harness="codex",
+        target=target, grants=AutoGrantStore(wolts)
+    )
+    assert policy.mode == "guarded"
+    assert policy.network_access is True
+    assert policy.approvals_reviewer == "auto_review"
+    assert set(policy.writable_roots) == {
+        str((wolts / "testwolt").resolve()),
+        str((wolts / "apps").resolve()),
+    }
+    assert str((wolts / "otherwolt").resolve()) not in policy.writable_roots
+    assert str((wolts / ".space").resolve()) not in policy.writable_roots
+    assert grant is None
 
-    Nothing on the spawn path asks for Auto by name — not the bot, not the
-    lodge — so a host default of prompt regardless of the grant meant every
-    unattended native session sat waiting for a human who was not there.
-    """
+
+def test_guarded_policy_round_trips_its_codex_settings():
+    policy = ExecutionPolicy(
+        mode="guarded",
+        isolation="host",
+        writable_roots=("/wolts/apps", "/wolts/maple"),
+        network_access=True,
+        approvals_reviewer="auto_review",
+    )
+    assert ExecutionPolicy.from_record(policy.to_record()) == policy
+
+
+def test_host_auto_grant_authorizes_but_does_not_select_full_auto(tmp_path):
     target, wolts = _target(tmp_path)
     store = AutoGrantStore(wolts)
     store.grant(target)
 
     policy, grant = resolve_execution_policy(
-        None, isolation="host", target=target, grants=store
+        None, isolation="host", harness="codex", target=target, grants=store
+    )
+    assert policy.mode == "guarded"
+    assert grant is None
+
+    policy, grant = resolve_execution_policy(
+        "auto", isolation="host", harness="codex", target=target, grants=store
     )
     assert policy == ExecutionPolicy(mode="auto", isolation="host")
     assert grant is not None
-    assert grant.canonical_workdir == target.canonical_workdir
 
 
 def test_a_grant_elsewhere_does_not_relax_this_target(tmp_path):
@@ -70,9 +101,9 @@ def test_a_grant_elsewhere_does_not_relax_this_target(tmp_path):
     store.grant(granted)
 
     policy, grant = resolve_execution_policy(
-        None, isolation="host", target=other, grants=store
+        None, isolation="host", harness="codex", target=other, grants=store
     )
-    assert policy.mode == "prompt"
+    assert policy.mode == "guarded"
     assert grant is None
 
 
@@ -83,7 +114,7 @@ def test_explicit_prompt_is_honored_even_where_auto_is_approved(tmp_path):
     store.grant(target)
 
     policy, grant = resolve_execution_policy(
-        "prompt", isolation="host", target=target, grants=store
+        "prompt", isolation="host", harness="codex", target=target, grants=store
     )
     assert policy == ExecutionPolicy(mode="prompt", isolation="host")
     assert grant is None
@@ -126,6 +157,15 @@ def test_host_auto_requires_exact_wolt_and_path(tmp_path):
         )
 
 
+def test_guarded_is_rejected_for_non_codex_harnesses(tmp_path):
+    target, wolts = _target(tmp_path)
+    with pytest.raises(ValueError, match="only by the codex"):
+        resolve_execution_policy(
+            "guarded", isolation="host", harness="claude",
+            target=target, grants=AutoGrantStore(wolts),
+        )
+
+
 def test_grant_for_same_path_does_not_cross_wolts(tmp_path):
     target_a, wolts = _target(tmp_path, wolt="alpha")
     target_b, _ = _target(tmp_path, wolt="beta")
@@ -149,6 +189,26 @@ def test_grant_store_is_versioned_private_and_revocable(tmp_path):
     assert store.revoke(target) is False
 
 
+def test_old_implicit_auto_grants_are_inactive_and_replaced(tmp_path):
+    target, wolts = _target(tmp_path)
+    store = AutoGrantStore(wolts)
+    store.path.parent.mkdir(parents=True)
+    store.path.write_text(json.dumps({"grants": [{
+        "wolt_id": target.wolt_id,
+        "canonical_workdir": str(target.canonical_workdir),
+        "policy_version": 1,
+        "approved_at": 1,
+    }]}) + "\n")
+
+    assert store.find(target) is None
+    assert store.list() == []
+    fresh = store.grant(target)
+    assert fresh.policy_version == POLICY_VERSION
+    payload = json.loads(store.path.read_text())
+    assert len(payload["grants"]) == 1
+    assert payload["grants"][0]["policy_version"] == POLICY_VERSION
+
+
 def test_start_session_native_policy_and_grant_are_persisted(
     tmp_path, monkeypatch, fake_runtime
 ):
@@ -159,7 +219,7 @@ def test_start_session_native_policy_and_grant_are_persisted(
     home = wolts / "testwolt"
     (home / "wolt" / "site").mkdir(parents=True)
     (home / "wolt" / "wolt.json").write_text(
-        json.dumps({"name": "testwolt", "type": "raccoon"})
+        json.dumps({"name": "testwolt", "type": "raccoon", "harness": "codex"})
     )
     repo = tmp_path / "repo"
     repo.mkdir()
@@ -168,9 +228,15 @@ def test_start_session_native_policy_and_grant_are_persisted(
     monkeypatch.setenv("WOLTSPACE_ISOLATION", "host")
 
     default = sessions.start_session(wolt="testwolt", workdir=repo)
-    assert default["execution_policy"]["mode"] == "prompt"
+    assert default["execution_policy"]["mode"] == "guarded"
+    assert default["execution_policy"]["network_access"] is True
+    assert str(home.resolve()) in default["execution_policy"]["writable_roots"]
+    assert str((wolts / "apps").resolve()) in default["execution_policy"]["writable_roots"]
     default_cmd = sessions.prepare_session_command(default["name"], "spawn")
-    assert "--dangerously-skip-permissions" not in default_cmd
+    assert "--sandbox workspace-write" in default_cmd
+    assert "--ask-for-approval on-request" in default_cmd
+    assert "approvals_reviewer=auto_review" in default_cmd
+    assert "--dangerously-bypass-approvals-and-sandbox" not in default_cmd
 
     target = SessionTarget.resolve("testwolt", repo, wolts_dir=wolts)
     AutoGrantStore(wolts).grant(target)
@@ -180,13 +246,11 @@ def test_start_session_native_policy_and_grant_are_persisted(
     assert automated["execution_policy"]["mode"] == "auto"
     assert automated["auto_grant"]["canonical_workdir"] == str(repo.resolve())
     auto_cmd = sessions.prepare_session_command(automated["name"], "spawn")
-    assert "--dangerously-skip-permissions" in auto_cmd
+    assert "--dangerously-bypass-approvals-and-sandbox" in auto_cmd
 
-    # And the caller that asks for nothing — every real spawn path — now gets
-    # the same Auto, because the grant is already there to say so.
+    # A standing grant authorizes Full Auto but never silently selects it.
     implicit = sessions.start_session(wolt="testwolt", workdir=repo)
-    assert implicit["execution_policy"]["mode"] == "auto"
-    assert implicit["auto_grant"]["canonical_workdir"] == str(repo.resolve())
-    assert "--dangerously-skip-permissions" in sessions.prepare_session_command(
-        implicit["name"], "spawn"
-    )
+    assert implicit["execution_policy"]["mode"] == "guarded"
+    assert implicit["auto_grant"] is None
+    assert "--sandbox workspace-write" in sessions.prepare_session_command(
+        implicit["name"], "spawn")

--- a/test/test_execution_policy.py
+++ b/test/test_execution_policy.py
@@ -93,6 +93,22 @@ def test_host_auto_grant_authorizes_but_does_not_select_full_auto(tmp_path):
     assert grant is not None
 
 
+def test_persistent_wolt_preference_selects_full_auto_without_a_launch_grant(tmp_path):
+    target, wolts = _target(tmp_path)
+
+    policy, grant = resolve_execution_policy(
+        "auto",
+        isolation="host",
+        harness="codex",
+        target=target,
+        grants=AutoGrantStore(wolts),
+        persistent=True,
+    )
+
+    assert policy == ExecutionPolicy(mode="auto", isolation="host")
+    assert grant is None
+
+
 def test_a_grant_elsewhere_does_not_relax_this_target(tmp_path):
     """The default is decided by the exact pair, like the enforcement is."""
     granted, wolts = _target(tmp_path, repo="repo-a")
@@ -254,3 +270,58 @@ def test_start_session_native_policy_and_grant_are_persisted(
     assert implicit["auto_grant"] is None
     assert "--sandbox workspace-write" in sessions.prepare_session_command(
         implicit["name"], "spawn")
+
+
+def test_start_session_honors_persistent_wolt_json_policy(
+    tmp_path, monkeypatch, fake_runtime
+):
+    import paths
+    import sessions
+
+    wolts = tmp_path / "wolts"
+    home = wolts / "testwolt"
+    (home / "wolt" / "site").mkdir(parents=True)
+    (home / "wolt" / "wolt.json").write_text(json.dumps({
+        "name": "testwolt",
+        "type": "raccoon",
+        "harness": "codex",
+        "execution_policy": "auto",
+    }))
+    monkeypatch.setattr(sessions, "WOLTS_DIR", wolts)
+    monkeypatch.setattr(paths, "WOLTS_DIR", wolts)
+    monkeypatch.setenv("WOLTSPACE_ISOLATION", "host")
+
+    persistent = sessions.start_session(wolt="testwolt")
+    assert persistent["execution_policy"]["mode"] == "auto"
+    assert persistent["auto_grant"] is None
+    assert "--dangerously-bypass-approvals-and-sandbox" in (
+        sessions.prepare_session_command(persistent["name"], "spawn")
+    )
+
+    overridden = sessions.start_session(
+        wolt="testwolt", execution_policy="prompt"
+    )
+    assert overridden["execution_policy"]["mode"] == "prompt"
+
+
+def test_start_session_rejects_invalid_wolt_json_policy(
+    tmp_path, monkeypatch, fake_runtime
+):
+    import paths
+    import sessions
+
+    wolts = tmp_path / "wolts"
+    home = wolts / "testwolt"
+    (home / "wolt" / "site").mkdir(parents=True)
+    (home / "wolt" / "wolt.json").write_text(json.dumps({
+        "name": "testwolt",
+        "type": "raccoon",
+        "harness": "codex",
+        "execution_policy": "reckless-ish",
+    }))
+    monkeypatch.setattr(sessions, "WOLTS_DIR", wolts)
+    monkeypatch.setattr(paths, "WOLTS_DIR", wolts)
+    monkeypatch.setenv("WOLTSPACE_ISOLATION", "host")
+
+    with pytest.raises(ValueError, match="unknown execution policy in"):
+        sessions.start_session(wolt="testwolt")

--- a/test/test_harnesses.py
+++ b/test/test_harnesses.py
@@ -146,6 +146,23 @@ class TestBuildCommandCodex:
         cmd = build_command("codex", "spawn", execution_policy="prompt")
         assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
 
+    def test_guarded_policy_uses_workspace_and_auto_review(self):
+        cmd = build_command("codex", "spawn", execution_policy={
+            "mode": "guarded",
+            "isolation": "host",
+            "writable_roots": ["/wolts/apps", "/wolts/maple"],
+            "network_access": True,
+            "approvals_reviewer": "auto_review",
+        })
+        assert "--sandbox workspace-write" in cmd
+        assert "--ask-for-approval on-request" in cmd
+        assert "approvals_reviewer=auto_review" in cmd
+        assert "sandbox_workspace_write.network_access=true" in cmd
+        assert "sandbox_workspace_write.writable_roots=" in cmd
+        assert "/wolts/apps" in cmd
+        assert "/wolts/maple" in cmd
+        assert "--dangerously-bypass-approvals-and-sandbox" not in cmd
+
     def test_codex_tier_models(self):
         """Mapped from the live /model picker (2026-07 lineup)."""
         assert creature_model("codex", "raccoon") == "gpt-5.5"

--- a/test/test_session_target_api.py
+++ b/test/test_session_target_api.py
@@ -39,9 +39,25 @@ def test_runtime_capabilities_distinguish_host_from_external(monkeypatch):
     assert response.json() == {
         "isolation": "host",
         "supports_host_workdirs": True,
+        "default_harness": "claude",
         "default_execution_policy": "prompt",
-        "policy_version": 1,
+        "default_execution_policies": {
+            "claude": "prompt",
+            "codex": "guarded",
+            "opencode": "prompt",
+        },
+        "policy_version": 2,
     }
+
+
+def test_runtime_capabilities_follow_a_codex_lodge_default(monkeypatch):
+    monkeypatch.setenv("WOLTSPACE_ISOLATION", "host")
+    monkeypatch.setattr(app_module, "get_default_harness", lambda: "codex")
+    response = asyncio.run(_request("GET", "/runtime/capabilities"))
+    assert response.status_code == 200
+    assert response.json()["default_harness"] == "codex"
+    assert response.json()["default_execution_policy"] == "guarded"
+    assert response.json()["default_execution_policies"]["claude"] == "prompt"
 
 
 def test_health_identifies_the_exact_control_plane(monkeypatch):

--- a/test/test_settings_page.py
+++ b/test/test_settings_page.py
@@ -14,12 +14,14 @@ async def _request(method, path, **kwargs):
         return await client.request(method, path, **kwargs)
 
 
-def _write_wolt(root, name, creature, harness=None):
+def _write_wolt(root, name, creature, harness=None, execution_policy=None):
     config_dir = root / name / "wolt"
     config_dir.mkdir(parents=True)
     config = {"name": name, "type": creature}
     if harness:
         config["harness"] = harness
+    if execution_policy:
+        config["execution_policy"] = execution_policy
     (config_dir / "wolt.json").write_text(json.dumps(config))
 
 
@@ -43,6 +45,9 @@ def test_settings_page_renders_defaults_and_overrides(tmp_path, monkeypatch):
     assert "Pinned · codex" in body
     assert 'data-wolt="fang"' not in body
     assert 'name="default-harness"' in body
+    assert "Session permissions" in body
+    assert 'data-policy-select' in body
+    assert 'value="auto"' in body
     assert 'role="dialog"' in body
     assert 'aria-labelledby="create-modal-title"' in body
 
@@ -56,15 +61,68 @@ def test_settings_assets_and_mutations_are_wired(tmp_path, monkeypatch):
     script = asyncio.run(_request("GET", "/static/settings.js"))
     default = asyncio.run(_request("POST", "/harness/default", json={"harness": "codex"}))
     override = asyncio.run(_request("POST", "/wolts/maple/harness", json={"harness": "claude"}))
+    policy = asyncio.run(_request(
+        "POST",
+        "/wolts/maple/execution-policy",
+        json={"execution_policy": "auto"},
+    ))
 
     assert css.status_code == 200
     assert ".ds-panel" in css.text
     assert script.status_code == 200
     assert "data-default-form" in script.text
+    assert "execution-policy" in script.text
     assert default.json() == {"ok": True, "default": "codex"}
     assert override.json() == {"ok": True, "wolt": "maple", "harness": "claude", "pinned": True}
+    assert policy.json() == {
+        "ok": True,
+        "wolt": "maple",
+        "execution_policy": "auto",
+        "pinned": True,
+        "source": "wolt.json",
+    }
     assert json.loads((tmp_path / "woltspace.json").read_text())["harness"]["default"] == "codex"
     assert json.loads((tmp_path / "maple" / "wolt" / "wolt.json").read_text())["harness"] == "claude"
+    assert json.loads((tmp_path / "maple" / "wolt" / "wolt.json").read_text())["execution_policy"] == "auto"
+
+
+def test_policy_mutation_clears_to_harness_default_and_validates_guarded(
+    tmp_path, monkeypatch
+):
+    _write_wolt(tmp_path, "maple", "raccoon", "claude", "auto")
+    monkeypatch.setattr(app_module, "WOLTS_DIR", tmp_path)
+    monkeypatch.setenv("WOLTSPACE_WOLTS_DIR", str(tmp_path))
+    monkeypatch.setenv("WOLTSPACE_ISOLATION", "host")
+
+    invalid = asyncio.run(_request(
+        "POST",
+        "/wolts/maple/execution-policy",
+        json={"execution_policy": "guarded"},
+    ))
+    assert invalid.status_code == 409
+    assert "Codex" in invalid.json()["error"]
+
+    cleared = asyncio.run(_request(
+        "POST",
+        "/wolts/maple/execution-policy",
+        json={"execution_policy": None},
+    ))
+    assert cleared.json() == {
+        "ok": True,
+        "wolt": "maple",
+        "execution_policy": "prompt",
+        "pinned": False,
+        "source": "harness_default",
+    }
+    config = json.loads((tmp_path / "maple" / "wolt" / "wolt.json").read_text())
+    assert "execution_policy" not in config
+
+    unknown = asyncio.run(_request(
+        "POST",
+        "/wolts/maple/execution-policy",
+        json={"execution_policy": "hope-for-the-best"},
+    ))
+    assert unknown.status_code == 400
 
 
 def test_configured_wolts_skips_broken_entries(tmp_path, monkeypatch):

--- a/test/test_trust_dir.py
+++ b/test/test_trust_dir.py
@@ -379,7 +379,7 @@ class TestSpawnPathTrustsWorkdir:
         result = self._start(app="dashboard")
         prepare_session_command(result["name"], "spawn", "hello")
 
-        assert result["workdir"].endswith("/wolt/apps/dashboard")
+        assert result["workdir"].endswith("/apps/dashboard")
         assert result["workdir"] in read_claude_json(claude_trust_home)["projects"]
 
     def test_codex_sessions_do_not_touch_claudes_config(self, fake_runtime, claude_trust_home):

--- a/test/test_wolts.py
+++ b/test/test_wolts.py
@@ -481,9 +481,27 @@ class TestStartSession:
         with patch("sessions.WOLTS_DIR", tmp_path):
             result = start_session(wolt="mywolt", app="myapp")
             assert result["app"] == "myapp"
-            assert (tmp_path / "mywolt" / "wolt" / "apps" / "myapp").is_dir()
+            assert (tmp_path / "apps" / "myapp").is_dir()
             # the app session runs inside the app subdir, not the wolt root
-            assert fake_runtime.last_spawn[1] == str(tmp_path / "mywolt" / "wolt" / "apps" / "myapp")
+            assert fake_runtime.last_spawn[1] == str(tmp_path / "apps" / "myapp")
+
+    def test_app_name_cannot_escape_shared_apps(self, tmp_path, fake_runtime):
+        from sessions import start_session
+        (tmp_path / "mywolt").mkdir()
+        with patch("sessions.WOLTS_DIR", tmp_path), pytest.raises(
+            ValueError, match="invalid app name"
+        ):
+            start_session(wolt="mywolt", app="../otherwolt")
+
+    def test_legacy_project_app_keeps_its_existing_directory(self, tmp_path, fake_runtime):
+        from sessions import start_session
+        (tmp_path / "mywolt").mkdir()
+        legacy = tmp_path / "projects" / "old-app"
+        legacy.mkdir(parents=True)
+        with patch("sessions.WOLTS_DIR", tmp_path):
+            result = start_session(wolt="mywolt", app="old-app")
+        assert result["workdir"] == str(legacy.resolve())
+        assert not (tmp_path / "apps" / "old-app").exists()
 
 
 # ---------------------------------------------------------------------------
@@ -626,7 +644,7 @@ class TestSyncClaudeMdPlatformSection:
 
         content = (wolt / "CLAUDE.md").read_text()
         assert "OLD STUFF" not in content
-        assert "DO NOT edit files outside" in content
+        assert "Edit only your wolt home" in content
         assert "# Alpha" in content
 
     def test_skips_wolts_without_claude_md(self, tmp_path):

--- a/tui/src/session-view.js
+++ b/tui/src/session-view.js
@@ -43,7 +43,8 @@ export const sessionPolicy = (session) => {
 export function spawnTarget(capabilities, wolt, launchCwd) {
   const native = capabilities?.supports_host_workdirs === true;
   const harness = wolt?.harness || capabilities?.default_harness;
-  const policy = capabilities?.default_execution_policies?.[harness]
+  const policy = wolt?.execution_policy
+    || capabilities?.default_execution_policies?.[harness]
     || capabilities?.default_execution_policy
     || (native ? 'prompt' : 'auto');
   return {

--- a/tui/src/session-view.js
+++ b/tui/src/session-view.js
@@ -42,10 +42,14 @@ export const sessionPolicy = (session) => {
 // signature for that future opt-in.
 export function spawnTarget(capabilities, wolt, launchCwd) {
   const native = capabilities?.supports_host_workdirs === true;
+  const harness = wolt?.harness || capabilities?.default_harness;
+  const policy = capabilities?.default_execution_policies?.[harness]
+    || capabilities?.default_execution_policy
+    || (native ? 'prompt' : 'auto');
   return {
     workdir: null,
     displayWorkdir: wolt?.home || 'wolt home',
-    executionPolicy: capabilities?.default_execution_policy || (native ? 'prompt' : 'auto'),
+    executionPolicy: policy,
     supportsHostWorkdirs: native,
   };
 }

--- a/tui/test/create-wolt.test.mjs
+++ b/tui/test/create-wolt.test.mjs
@@ -17,14 +17,16 @@ test('native create action starts the new wolt in its own home', () => {
     'maple', 'raccoon', {
       isolation: 'host',
       supports_host_workdirs: true,
-      default_execution_policy: 'prompt',
+      default_harness: 'codex',
+      default_execution_policy: 'guarded',
+      default_execution_policies: { claude: 'prompt', codex: 'guarded' },
     }, '/src/project',
   ), {
     type: 'create',
     name: 'maple',
     woltType: 'raccoon',
     workdir: null,
-    executionPolicy: 'prompt',
+    executionPolicy: 'guarded',
     isolation: 'host',
   });
 });

--- a/tui/test/session-view.test.mjs
+++ b/tui/test/session-view.test.mjs
@@ -23,12 +23,16 @@ test('legacy session view keeps old dir and implicit Auto visible', () => {
 
 test('native spawn roots the wolt in its own home, not the launch directory', () => {
   assert.deepEqual(
-    spawnTarget({ supports_host_workdirs: true, default_execution_policy: 'prompt' },
-      { home: '/wolts/maple' }, '/src/project'),
+    spawnTarget({
+      supports_host_workdirs: true,
+      default_harness: 'claude',
+      default_execution_policy: 'prompt',
+      default_execution_policies: { claude: 'prompt', codex: 'guarded' },
+    }, { home: '/wolts/maple', harness: 'codex' }, '/src/project'),
     {
       workdir: null,
       displayWorkdir: '/wolts/maple',
-      executionPolicy: 'prompt',
+      executionPolicy: 'guarded',
       supportsHostWorkdirs: true,
     },
   );
@@ -50,7 +54,12 @@ test('container spawn keeps the existing wolt-home default', () => {
 // Two wolts woken from the same terminal must not share a root. Before this,
 // native handed both of them the one directory the TUI was launched from.
 test('two wolts woken from one launch directory land in their own homes', () => {
-  const caps = { supports_host_workdirs: true, default_execution_policy: 'prompt' };
+  const caps = {
+    supports_host_workdirs: true,
+    default_harness: 'codex',
+    default_execution_policy: 'guarded',
+    default_execution_policies: { claude: 'prompt', codex: 'guarded' },
+  };
   const a = spawnTarget(caps, { home: '/wolts/maple' }, '/wolts/birch');
   const b = spawnTarget(caps, { home: '/wolts/birch' }, '/wolts/birch');
   assert.equal(a.workdir, null);

--- a/tui/test/session-view.test.mjs
+++ b/tui/test/session-view.test.mjs
@@ -38,6 +38,19 @@ test('native spawn roots the wolt in its own home, not the launch directory', ()
   );
 });
 
+test('a wolt policy pin wins over the harness default on every future spawn', () => {
+  const target = spawnTarget({
+    supports_host_workdirs: true,
+    default_harness: 'codex',
+    default_execution_policy: 'guarded',
+    default_execution_policies: { claude: 'prompt', codex: 'guarded' },
+  }, {
+    home: '/wolts/maple', harness: 'codex', execution_policy: 'auto',
+  }, '/src/project');
+
+  assert.equal(target.executionPolicy, 'auto');
+});
+
 test('container spawn keeps the existing wolt-home default', () => {
   assert.deepEqual(
     spawnTarget({ supports_host_workdirs: false, default_execution_policy: 'auto' },


### PR DESCRIPTION
## Summary

- make Guarded the native default for every Codex wolt across lodge, Telegram, Slack, and the TUI
- launch Codex with `workspace-write`, network access, and `approvals_reviewer=auto_review`
- derive writable scope per session: the current workdir, the owning wolt home, and shared `wolts/apps/`; sibling homes and `.space` remain out of scope
- add a per-wolt Session permissions control to platform Settings: Follow default, Prompt, Guarded, or Full Auto
- persist that choice as `execution_policy` in the wolt’s own `wolt/wolt.json`, matching the existing self-managed harness/model pattern
- honor the saved choice on every future lodge, Telegram, Slack, TUI, scheduled, and app-scoped wake; an explicit per-spawn override still wins
- keep exact-target grants for one-off Full Auto launches that should not change the durable wolt setting
- retain prompt mode for native Claude/opencode and Auto for externally sandboxed containers

Codex contract: https://developers.openai.com/codex/agent-approvals-security/

## Verification

- 29 directly affected Python tests passed (policy resolution, central session launch, Settings render/API, capability contract)
- 29 TUI tests passed
- Python compile checks, JavaScript syntax check, and `git diff --check` passed
- built the wheel and confirmed it contains the updated runtime, server, Settings template, and Settings JavaScript
- updated start-chat skill passed the skill validator
- generated flags parsed successfully with `codex-cli 0.153.4`

The earlier broad local pytest probe reached 1309 passed / 16 skipped; its environment-dependent or pre-existing failures were in live-agent, container-path, host-auth/model-overlay, and missing-checkout-dependency tests. A later broad probe likewise found no failures in the changed permission/settings scope.

Visual note: the in-app browser was unavailable in this session. The Settings surface has render/API/static checks, but should get a quick visual click-through before merge.