### PR TITLE
Make notify messages shell-safe across harnesses

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,7 @@ The agent loop is multi-turn — Haiku can chain tool calls. Tools live in `core
 ### Notify back: Claude → user
 
 ```
-Claude in session calls: notify "done, check it out"
+Claude in session passes the message through a single-quoted heredoc to: notify
   → bin/notify                                     wolt-facing helper
   → POST /notify on FastAPI
   → server reads session routing from registry

--- a/container/bin/create-creature-wolt
+++ b/container/bin/create-creature-wolt
@@ -24,7 +24,9 @@ from sites import ensure_site
 def _notify(message: str) -> None:
     """Send a notification via the notify script if available."""
     try:
-        subprocess.run(["notify", message], timeout=10, capture_output=True)
+        subprocess.run(
+            ["notify"], input=message, text=True, timeout=10, capture_output=True
+        )
     except (FileNotFoundError, subprocess.TimeoutExpired):
         pass
 

--- a/container/bin/notify
+++ b/container/bin/notify
@@ -2,10 +2,12 @@
 # Send a notification to the originating chat (Telegram/Slack)
 #
 # Usage:
-#   notify "message"                                  — auto-route via session registry (default: telegram)
-#   notify --stdin                                     — read the message literally from standard input
-#   notify --slack CHANNEL THREAD_TS "message"        — send to specific Slack thread
-#   notify --telegram CHAT_ID --stdin                  — safely read a Telegram message from stdin
+#   notify                                             — auto-route via session registry (default: telegram)
+#   notify --slack CHANNEL THREAD_TS                   — send to a specific Slack thread
+#   notify --telegram CHAT_ID                          — send to a specific Telegram chat
+#
+# Message text is always read literally from standard input. Agents should use
+# a single-quoted heredoc with a fresh delimiter so the shell cannot expand it.
 #
 # The --slack and --telegram flags let rodents explicitly target where to send,
 # based on the adapter info in their prepended message context.
@@ -19,11 +21,11 @@ TELEGRAM_CHAT_ID=""
 usage() {
   printf '%s\n' \
     'Usage:' \
-    '  notify [--stdin | "message"]' \
-    '  notify --telegram CHAT_ID [--stdin | "message"]' \
-    '  notify --slack CHANNEL THREAD_TS [--stdin | "message"]' \
+    '  notify' \
+    '  notify --telegram CHAT_ID' \
+    '  notify --slack CHANNEL THREAD_TS' \
     '' \
-    'Use --stdin for generated or user-controlled text so the shell never parses the message.'
+    'Message text is read from standard input. Use a single-quoted heredoc.'
 }
 
 fail_usage() {
@@ -42,6 +44,8 @@ case "${1:-}" in
     ADAPTER="slack"
     SLACK_CHANNEL="$2"
     SLACK_THREAD="$3"
+    [[ "$SLACK_CHANNEL" =~ ^[A-Za-z0-9_-]+$ ]] || fail_usage "CHANNEL has invalid characters"
+    [[ "$SLACK_THREAD" =~ ^[0-9]+([.][0-9]+)?$ ]] || fail_usage "THREAD_TS must be numeric"
     shift 3
     ;;
   --telegram)
@@ -59,30 +63,11 @@ case "${1:-}" in
     ;;
 esac
 
-case "${1:-}" in
-  -h|--help)
-    usage
-    exit 0
-    ;;
-  --stdin)
-    [ "$#" -eq 1 ] || fail_usage "--stdin does not accept a message argument"
-    # The sentinel prevents command substitution from stripping trailing newlines.
-    MESSAGE="$(cat; printf '\034')"
-    MESSAGE="${MESSAGE%$'\034'}"
-    ;;
-  --)
-    shift
-    [ "$#" -eq 1 ] || fail_usage "expected exactly one message after --"
-    MESSAGE="$1"
-    ;;
-  --*)
-    fail_usage "unknown option: $1"
-    ;;
-  *)
-    [ "$#" -eq 1 ] || fail_usage "expected exactly one message or --stdin"
-    MESSAGE="${1:-}"
-    ;;
-esac
+[ "$#" -eq 0 ] || fail_usage "message arguments are not supported; pass message text on stdin"
+
+# The sentinel prevents command substitution from stripping trailing newlines.
+MESSAGE="$(cat; printf '\034')"
+MESSAGE="${MESSAGE%$'\034'}"
 
 if [ -z "$MESSAGE" ]; then
   fail_usage "message must not be empty"

--- a/container/bin/notify
+++ b/container/bin/notify
@@ -35,7 +35,11 @@ fail_usage() {
 }
 
 fail_message_args() {
-  local body="$*"
+  if [ "$#" -ne 1 ]; then
+    fail_usage "message arguments are not supported; pass one message body on stdin"
+  fi
+
+  local body="$1"
   local delimiter
 
   while true; do
@@ -45,8 +49,9 @@ fail_message_args() {
     fi
   done
 
-  printf '%s\n\n' \
+  printf '%s\n%s\n\n' \
     'notify: message arguments are not supported; pass message text on stdin' \
+    'Caution: this body is only what survived shell expansion; check it before sending.' \
     'Run this instead:' >&2
   case "$ADAPTER" in
     slack)

--- a/container/bin/notify
+++ b/container/bin/notify
@@ -34,6 +34,37 @@ fail_usage() {
   exit 2
 }
 
+fail_message_args() {
+  local body="$*"
+  local delimiter
+
+  while true; do
+    delimiter="WOLTSPACE_NOTIFY_$(python3 -c 'import secrets; print(secrets.token_hex(8).upper())')"
+    if ! printf '%s\n' "$body" | grep -Fqx "$delimiter"; then
+      break
+    fi
+  done
+
+  printf '%s\n\n' \
+    'notify: message arguments are not supported; pass message text on stdin' \
+    'Run this instead:' >&2
+  case "$ADAPTER" in
+    slack)
+      printf "notify --slack %s %s <<'%s'\n" \
+        "$SLACK_CHANNEL" "$SLACK_THREAD" "$delimiter" >&2
+      ;;
+    telegram)
+      printf "notify --telegram %s <<'%s'\n" \
+        "$TELEGRAM_CHAT_ID" "$delimiter" >&2
+      ;;
+    *)
+      printf "notify <<'%s'\n" "$delimiter" >&2
+      ;;
+  esac
+  printf '%s\n%s\n' "$body" "$delimiter" >&2
+  exit 2
+}
+
 case "${1:-}" in
   -h|--help)
     usage
@@ -63,7 +94,7 @@ case "${1:-}" in
     ;;
 esac
 
-[ "$#" -eq 0 ] || fail_usage "message arguments are not supported; pass message text on stdin"
+[ "$#" -eq 0 ] || fail_message_args "$@"
 
 # The sentinel prevents command substitution from stripping trailing newlines.
 MESSAGE="$(cat; printf '\034')"

--- a/container/bin/notify
+++ b/container/bin/notify
@@ -3,8 +3,9 @@
 #
 # Usage:
 #   notify "message"                                  — auto-route via session registry (default: telegram)
+#   notify --stdin                                     — read the message literally from standard input
 #   notify --slack CHANNEL THREAD_TS "message"        — send to specific Slack thread
-#   notify --telegram CHAT_ID "message"               — send to specific Telegram chat
+#   notify --telegram CHAT_ID --stdin                  — safely read a Telegram message from stdin
 #
 # The --slack and --telegram flags let rodents explicitly target where to send,
 # based on the adapter info in their prepended message context.
@@ -15,24 +16,76 @@ SLACK_CHANNEL=""
 SLACK_THREAD=""
 TELEGRAM_CHAT_ID=""
 
-case "$1" in
+usage() {
+  printf '%s\n' \
+    'Usage:' \
+    '  notify [--stdin | "message"]' \
+    '  notify --telegram CHAT_ID [--stdin | "message"]' \
+    '  notify --slack CHANNEL THREAD_TS [--stdin | "message"]' \
+    '' \
+    'Use --stdin for generated or user-controlled text so the shell never parses the message.'
+}
+
+fail_usage() {
+  echo "notify: $1" >&2
+  usage >&2
+  exit 2
+}
+
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
   --slack)
+    [ "$#" -ge 3 ] || fail_usage "--slack requires CHANNEL and THREAD_TS"
     ADAPTER="slack"
-    SLACK_CHANNEL="${2:-}"
-    SLACK_THREAD="${3:-}"
-    shift 3 2>/dev/null || { echo "Usage: notify --slack CHANNEL THREAD_TS \"message\"" >&2; exit 1; }
+    SLACK_CHANNEL="$2"
+    SLACK_THREAD="$3"
+    shift 3
     ;;
   --telegram)
+    [ "$#" -ge 2 ] || fail_usage "--telegram requires CHAT_ID"
     ADAPTER="telegram"
-    TELEGRAM_CHAT_ID="${2:-}"
-    shift 2 2>/dev/null || { echo "Usage: notify --telegram CHAT_ID \"message\"" >&2; exit 1; }
+    TELEGRAM_CHAT_ID="$2"
+    [[ "$TELEGRAM_CHAT_ID" =~ ^-?[0-9]+$ ]] || fail_usage "CHAT_ID must be an integer"
+    shift 2
+    ;;
+  --)
+    shift
+    ;;
+  --*)
+    fail_usage "unknown option: $1"
     ;;
 esac
 
-MESSAGE="${1:-}"
+case "${1:-}" in
+  -h|--help)
+    usage
+    exit 0
+    ;;
+  --stdin)
+    [ "$#" -eq 1 ] || fail_usage "--stdin does not accept a message argument"
+    # The sentinel prevents command substitution from stripping trailing newlines.
+    MESSAGE="$(cat; printf '\034')"
+    MESSAGE="${MESSAGE%$'\034'}"
+    ;;
+  --)
+    shift
+    [ "$#" -eq 1 ] || fail_usage "expected exactly one message after --"
+    MESSAGE="$1"
+    ;;
+  --*)
+    fail_usage "unknown option: $1"
+    ;;
+  *)
+    [ "$#" -eq 1 ] || fail_usage "expected exactly one message or --stdin"
+    MESSAGE="${1:-}"
+    ;;
+esac
+
 if [ -z "$MESSAGE" ]; then
-  echo "Usage: notify [--slack CHANNEL THREAD_TS | --telegram CHAT_ID] \"message\"" >&2
-  exit 1
+  fail_usage "message must not be empty"
 fi
 
 # Both spellings: the platform stamps WOLTSPACE_WOLT_SESSION, older shells

--- a/container/bot/AGENT-LOOP.md
+++ b/container/bot/AGENT-LOOP.md
@@ -51,11 +51,11 @@ from tools, not from its own knowledge.
 
 ### Flow 2: Den reports back (claude code -> human, haiku is spectator)
 
-When a Claude Code session calls `notify "message"`, it goes directly to the
+When a Claude Code session passes a message on stdin to `notify --stdin`, it goes directly to the
 human. Haiku is not involved but gets the message as context.
 
 ```
-Claude Code session: notify "site's up, check the viewport"
+Claude Code session: notify --stdin (message supplied through the process's stdin)
   |
   v
 container/bin/notify (formats message with session URL)

--- a/container/bot/AGENT-LOOP.md
+++ b/container/bot/AGENT-LOOP.md
@@ -51,11 +51,11 @@ from tools, not from its own knowledge.
 
 ### Flow 2: Den reports back (claude code -> human, haiku is spectator)
 
-When a Claude Code session passes a message on stdin to `notify --stdin`, it goes directly to the
+When a Claude Code session passes a message to `notify` through a single-quoted heredoc, it goes directly to the
 human. Haiku is not involved but gets the message as context.
 
 ```
-Claude Code session: notify --stdin (message supplied through the process's stdin)
+Claude Code session: notify (message supplied through a single-quoted heredoc)
   |
   v
 container/bin/notify (formats message with session URL)

--- a/container/bot/slack_adapter.py
+++ b/container/bot/slack_adapter.py
@@ -352,7 +352,7 @@ async def _route_to_session(client, channel: str, thread_ts: str, owner: dict, t
 
     session_msg = (
         f"[slack message from human, channel={channel}, thread={thread_ts}]: {text}\n"
-        f"Reply back to them with: notify --slack {channel} {thread_ts} \"your message\""
+        f"Reply by passing message text on stdin to: notify --slack {channel} {thread_ts} --stdin"
     )
     # Blocking resume wait — off the event loop, or the whole Slack app stops
     # answering while one session boots.

--- a/container/bot/slack_adapter.py
+++ b/container/bot/slack_adapter.py
@@ -352,7 +352,7 @@ async def _route_to_session(client, channel: str, thread_ts: str, owner: dict, t
 
     session_msg = (
         f"[slack message from human, channel={channel}, thread={thread_ts}]: {text}\n"
-        f"Reply by passing message text on stdin to: notify --slack {channel} {thread_ts} --stdin"
+        f"Reply using a single-quoted heredoc with: notify --slack {channel} {thread_ts}"
     )
     # Blocking resume wait — off the event loop, or the whole Slack app stops
     # answering while one session boots.

--- a/container/bot/slack_adapter.py
+++ b/container/bot/slack_adapter.py
@@ -31,6 +31,7 @@ from wolts import get_active_creature
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from env_compat import get_env
 from paths import wolt_state_dir, wolt_chat_dir
+from notify_prompt import notify_reply_instruction
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -352,7 +353,7 @@ async def _route_to_session(client, channel: str, thread_ts: str, owner: dict, t
 
     session_msg = (
         f"[slack message from human, channel={channel}, thread={thread_ts}]: {text}\n"
-        f"Reply using a single-quoted heredoc with: notify --slack {channel} {thread_ts}"
+        f"{notify_reply_instruction('--slack', channel, thread_ts)}"
     )
     # Blocking resume wait — off the event loop, or the whole Slack app stops
     # answering while one session boots.

--- a/container/bot/telegram_adapter.py
+++ b/container/bot/telegram_adapter.py
@@ -345,7 +345,7 @@ async def _route_to_session(update: Update, session_name: str, wolt: str, text: 
 
     session_msg = (
         f"[telegram message from human, chat_id={chat_id}]: {text}\n"
-        f"Reply by passing message text on stdin to: notify --telegram {chat_id} --stdin"
+        f"Reply using a single-quoted heredoc with: notify --telegram {chat_id}"
     )
     # message_session → resume_session blocks for as long as the agent takes
     # to come up (up to 12s). On the bot's event loop that stalls every other

--- a/container/bot/telegram_adapter.py
+++ b/container/bot/telegram_adapter.py
@@ -41,6 +41,7 @@ from session_runtime import RuntimeHandle, get_runtime
 from sessions import resolve_active_session, wolt_harness
 from harnesses import platform_skill_invoke
 from skills_sync import wolt_skills_delivery
+from notify_prompt import notify_reply_instruction
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -345,7 +346,7 @@ async def _route_to_session(update: Update, session_name: str, wolt: str, text: 
 
     session_msg = (
         f"[telegram message from human, chat_id={chat_id}]: {text}\n"
-        f"Reply using a single-quoted heredoc with: notify --telegram {chat_id}"
+        f"{notify_reply_instruction('--telegram', chat_id)}"
     )
     # message_session → resume_session blocks for as long as the agent takes
     # to come up (up to 12s). On the bot's event loop that stalls every other

--- a/container/bot/telegram_adapter.py
+++ b/container/bot/telegram_adapter.py
@@ -345,7 +345,7 @@ async def _route_to_session(update: Update, session_name: str, wolt: str, text: 
 
     session_msg = (
         f"[telegram message from human, chat_id={chat_id}]: {text}\n"
-        f"Reply back to them with: notify --telegram {chat_id} \"your message\""
+        f"Reply by passing message text on stdin to: notify --telegram {chat_id} --stdin"
     )
     # message_session → resume_session blocks for as long as the agent takes
     # to come up (up to 12s). On the bot's event loop that stalls every other

--- a/container/bot/telegram_adapter_v1.py
+++ b/container/bot/telegram_adapter_v1.py
@@ -218,7 +218,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
         den_msg = (
             f"[telegram message from {human_name}, chat_id={chat_id}]: {text}\n"
-            f"Reply by passing message text on stdin to: notify --telegram {chat_id} --stdin"
+            f"Reply using a single-quoted heredoc with: notify --telegram {chat_id}"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply", {"session": den_session, "text": text[:200], "result": result})
@@ -336,7 +336,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
         voice_chat_id = update.effective_chat.id
         den_msg = (
             f"[telegram voice from {human_name}, chat_id={voice_chat_id}]: {text}\n"
-            f"Reply by passing message text on stdin to: notify --telegram {voice_chat_id} --stdin"
+            f"Reply using a single-quoted heredoc with: notify --telegram {voice_chat_id}"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply_voice", {"session": den_session, "text": text[:200], "result": result})
@@ -520,7 +520,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE):
         human_name = "human"
         den_msg = (
             f"[telegram file from {human_name}, chat_id={chat_id}]: {user_message}\n"
-            f"Reply by passing message text on stdin to: notify --telegram {chat_id} --stdin"
+            f"Reply using a single-quoted heredoc with: notify --telegram {chat_id}"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply_file", {"session": den_session, "file": file_name, "path": str(saved_path), "result": result})

--- a/container/bot/telegram_adapter_v1.py
+++ b/container/bot/telegram_adapter_v1.py
@@ -218,7 +218,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
         den_msg = (
             f"[telegram message from {human_name}, chat_id={chat_id}]: {text}\n"
-            f"Reply back to them with: notify --telegram {chat_id} \"your message\""
+            f"Reply by passing message text on stdin to: notify --telegram {chat_id} --stdin"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply", {"session": den_session, "text": text[:200], "result": result})
@@ -336,7 +336,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
         voice_chat_id = update.effective_chat.id
         den_msg = (
             f"[telegram voice from {human_name}, chat_id={voice_chat_id}]: {text}\n"
-            f"Reply back to them with: notify --telegram {voice_chat_id} \"your message\""
+            f"Reply by passing message text on stdin to: notify --telegram {voice_chat_id} --stdin"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply_voice", {"session": den_session, "text": text[:200], "result": result})
@@ -520,7 +520,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE):
         human_name = "human"
         den_msg = (
             f"[telegram file from {human_name}, chat_id={chat_id}]: {user_message}\n"
-            f"Reply back to them with: notify --telegram {chat_id} \"your message\""
+            f"Reply by passing message text on stdin to: notify --telegram {chat_id} --stdin"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply_file", {"session": den_session, "file": file_name, "path": str(saved_path), "result": result})

--- a/container/bot/telegram_adapter_v1.py
+++ b/container/bot/telegram_adapter_v1.py
@@ -24,6 +24,7 @@ from wolts import get_active_creature
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
 from env_compat import get_env
 from paths import wolt_state_dir, wolt_chat_dir, wolt_uploads_dir
+from notify_prompt import notify_reply_instruction
 
 logging.basicConfig(
     format="%(asctime)s - %(name)s - %(levelname)s - %(message)s",
@@ -218,7 +219,7 @@ async def handle_message(update: Update, context: ContextTypes.DEFAULT_TYPE):
         chat_id = update.effective_chat.id
         den_msg = (
             f"[telegram message from {human_name}, chat_id={chat_id}]: {text}\n"
-            f"Reply using a single-quoted heredoc with: notify --telegram {chat_id}"
+            f"{notify_reply_instruction('--telegram', chat_id)}"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply", {"session": den_session, "text": text[:200], "result": result})
@@ -336,7 +337,7 @@ async def handle_voice(update: Update, context: ContextTypes.DEFAULT_TYPE):
         voice_chat_id = update.effective_chat.id
         den_msg = (
             f"[telegram voice from {human_name}, chat_id={voice_chat_id}]: {text}\n"
-            f"Reply using a single-quoted heredoc with: notify --telegram {voice_chat_id}"
+            f"{notify_reply_instruction('--telegram', voice_chat_id)}"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply_voice", {"session": den_session, "text": text[:200], "result": result})
@@ -520,7 +521,7 @@ async def handle_document(update: Update, context: ContextTypes.DEFAULT_TYPE):
         human_name = "human"
         den_msg = (
             f"[telegram file from {human_name}, chat_id={chat_id}]: {user_message}\n"
-            f"Reply using a single-quoted heredoc with: notify --telegram {chat_id}"
+            f"{notify_reply_instruction('--telegram', chat_id)}"
         )
         result = await asyncio.to_thread(message_session, den_session, den_msg)
         _bot_log("den_reply_file", {"session": den_session, "file": file_name, "path": str(saved_path), "result": result})

--- a/container/bot/test_notify_flow.py
+++ b/container/bot/test_notify_flow.py
@@ -135,11 +135,11 @@ class TestDenReplyMessageFormat:
         text = "hey can you check the logs?"
         den_msg = (
             f"[telegram message from {human_name}]: {text}\n"
-            f"Reply by passing message text on stdin to: notify --stdin"
+            f"Reply using a single-quoted heredoc with: notify"
         )
         assert "[telegram message from jerpint]" in den_msg
         assert text in den_msg
-        assert "notify --stdin" in den_msg
+        assert "single-quoted heredoc" in den_msg
 
     def test_voice_reply_format(self):
         """Voice reply should include origin and notify instruction."""
@@ -147,11 +147,11 @@ class TestDenReplyMessageFormat:
         text = "transcribed voice message"
         den_msg = (
             f"[telegram voice from {human_name}]: {text}\n"
-            f"Reply by passing message text on stdin to: notify --stdin"
+            f"Reply using a single-quoted heredoc with: notify"
         )
         assert "[telegram voice from jerpint]" in den_msg
         assert text in den_msg
-        assert "notify --stdin" in den_msg
+        assert "single-quoted heredoc" in den_msg
 
 
 # ---------------------------------------------------------------------------

--- a/container/bot/test_notify_flow.py
+++ b/container/bot/test_notify_flow.py
@@ -131,27 +131,35 @@ class TestDenReplyMessageFormat:
 
     def test_text_reply_format(self):
         """Text reply should include origin and notify instruction."""
+        from notify_prompt import notify_reply_instruction
+
         human_name = "jerpint"
         text = "hey can you check the logs?"
         den_msg = (
             f"[telegram message from {human_name}]: {text}\n"
-            f"Reply using a single-quoted heredoc with: notify"
+            f"{notify_reply_instruction('--telegram', 123)}"
         )
         assert "[telegram message from jerpint]" in den_msg
         assert text in den_msg
         assert "single-quoted heredoc" in den_msg
+        assert "notify --telegram 123 <<'" in den_msg
+        assert "YOUR_REPLY" in den_msg
 
     def test_voice_reply_format(self):
         """Voice reply should include origin and notify instruction."""
+        from notify_prompt import notify_reply_instruction
+
         human_name = "jerpint"
         text = "transcribed voice message"
         den_msg = (
             f"[telegram voice from {human_name}]: {text}\n"
-            f"Reply using a single-quoted heredoc with: notify"
+            f"{notify_reply_instruction('--telegram', 123)}"
         )
         assert "[telegram voice from jerpint]" in den_msg
         assert text in den_msg
         assert "single-quoted heredoc" in den_msg
+        assert "notify --telegram 123 <<'" in den_msg
+        assert "YOUR_REPLY" in den_msg
 
 
 # ---------------------------------------------------------------------------

--- a/container/bot/test_notify_flow.py
+++ b/container/bot/test_notify_flow.py
@@ -135,11 +135,11 @@ class TestDenReplyMessageFormat:
         text = "hey can you check the logs?"
         den_msg = (
             f"[telegram message from {human_name}]: {text}\n"
-            f"Reply back to them with: notify \"your message\""
+            f"Reply by passing message text on stdin to: notify --stdin"
         )
         assert "[telegram message from jerpint]" in den_msg
         assert text in den_msg
-        assert 'notify "your message"' in den_msg
+        assert "notify --stdin" in den_msg
 
     def test_voice_reply_format(self):
         """Voice reply should include origin and notify instruction."""
@@ -147,11 +147,11 @@ class TestDenReplyMessageFormat:
         text = "transcribed voice message"
         den_msg = (
             f"[telegram voice from {human_name}]: {text}\n"
-            f"Reply back to them with: notify \"your message\""
+            f"Reply by passing message text on stdin to: notify --stdin"
         )
         assert "[telegram voice from jerpint]" in den_msg
         assert text in den_msg
-        assert 'notify "your message"' in den_msg
+        assert "notify --stdin" in den_msg
 
 
 # ---------------------------------------------------------------------------

--- a/container/cron/check-update.sh
+++ b/container/cron/check-update.sh
@@ -53,7 +53,7 @@ fi
 
 # Update available — notify once, then stamp the new version so we don't spam
 MESSAGE="a woltspace update is available ($LOCAL_VERSION -> $LATEST_TAG). to find out what changed, ask: \"can you update woltspace?\""
-notify "$MESSAGE"
+printf '%s' "$MESSAGE" | notify
 
 # Stamp the new remote tag so we only notify once per release
 echo "$LATEST_TAG" > "$VERSION_FILE"

--- a/container/lib/notify_prompt.py
+++ b/container/lib/notify_prompt.py
@@ -8,7 +8,26 @@ import shlex
 
 
 _DELIMITER_RE = re.compile(r"WOLTSPACE_NOTIFY_[A-F0-9]{16}")
+_SLACK_CHANNEL_RE = re.compile(r"[A-Za-z0-9_-]+")
+_SLACK_THREAD_RE = re.compile(r"[0-9]+(?:\.[0-9]+)?")
+_TELEGRAM_CHAT_ID_RE = re.compile(r"-?[0-9]+")
 _REPLY_PLACEHOLDER = "YOUR_REPLY"
+
+
+def _validate_route_args(route_args: tuple[str, ...]) -> None:
+    if not route_args:
+        return
+    if route_args[0] == "--slack" and len(route_args) == 3:
+        if _SLACK_CHANNEL_RE.fullmatch(route_args[1]) is None:
+            raise ValueError("Slack channel has invalid characters")
+        if _SLACK_THREAD_RE.fullmatch(route_args[2]) is None:
+            raise ValueError("Slack thread timestamp must be numeric")
+        return
+    if route_args[0] == "--telegram" and len(route_args) == 2:
+        if _TELEGRAM_CHAT_ID_RE.fullmatch(route_args[1]) is None:
+            raise ValueError("Telegram chat ID must be an integer")
+        return
+    raise ValueError("invalid notify route arguments")
 
 
 def notify_heredoc(
@@ -22,6 +41,8 @@ def notify_heredoc(
     message text cannot accidentally terminate the heredoc. ``body`` exists so
     tests can execute the exact formatter used in prompts with adversarial text.
     """
+    route_args = tuple(str(arg) for arg in route_args)
+    _validate_route_args(route_args)
     body = str(body)
     if delimiter is not None:
         if _DELIMITER_RE.fullmatch(delimiter) is None:
@@ -35,7 +56,7 @@ def notify_heredoc(
             if marker not in body.splitlines():
                 break
 
-    command = shlex.join(["notify", *(str(arg) for arg in route_args)])
+    command = shlex.join(["notify", *route_args])
     marker_separator = "" if body.endswith("\n") else "\n"
     return f"{command} <<'{marker}'\n{body}{marker_separator}{marker}"
 

--- a/container/lib/notify_prompt.py
+++ b/container/lib/notify_prompt.py
@@ -1,0 +1,49 @@
+"""Build shell-safe, self-contained instructions for replying through notify."""
+
+from __future__ import annotations
+
+import re
+import secrets
+import shlex
+
+
+_DELIMITER_RE = re.compile(r"WOLTSPACE_NOTIFY_[A-F0-9]{16}")
+_REPLY_PLACEHOLDER = "YOUR_REPLY"
+
+
+def notify_heredoc(
+    *route_args: object,
+    body: str = _REPLY_PLACEHOLDER,
+    delimiter: str | None = None,
+) -> str:
+    """Return an executable quoted heredoc for ``notify``.
+
+    Route arguments are shell-quoted and the delimiter is generated afresh so
+    message text cannot accidentally terminate the heredoc. ``body`` exists so
+    tests can execute the exact formatter used in prompts with adversarial text.
+    """
+    body = str(body)
+    if delimiter is not None:
+        if _DELIMITER_RE.fullmatch(delimiter) is None:
+            raise ValueError("invalid notify heredoc delimiter")
+        if delimiter in body.splitlines():
+            raise ValueError("notify heredoc delimiter collides with message body")
+        marker = delimiter
+    else:
+        while True:
+            marker = f"WOLTSPACE_NOTIFY_{secrets.token_hex(8).upper()}"
+            if marker not in body.splitlines():
+                break
+
+    command = shlex.join(["notify", *(str(arg) for arg in route_args)])
+    marker_separator = "" if body.endswith("\n") else "\n"
+    return f"{command} <<'{marker}'\n{body}{marker_separator}{marker}"
+
+
+def notify_reply_instruction(*route_args: object) -> str:
+    """Tell an agent exactly how to send a reply without loading a skill."""
+    return (
+        f"Reply by replacing {_REPLY_PLACEHOLDER} in this exact single-quoted "
+        "heredoc, then run it:\n"
+        f"{notify_heredoc(*route_args)}"
+    )

--- a/container/lib/notify_prompt.py
+++ b/container/lib/notify_prompt.py
@@ -63,8 +63,14 @@ def notify_heredoc(
 
 def notify_reply_instruction(*route_args: object) -> str:
     """Tell an agent exactly how to send a reply without loading a skill."""
+    try:
+        heredoc = notify_heredoc(*route_args)
+    except ValueError:
+        # Bad adapter metadata should not break message routing. The unrouted
+        # command can still resolve the destination through the session registry.
+        heredoc = notify_heredoc()
     return (
         f"Reply by replacing {_REPLY_PLACEHOLDER} in this exact single-quoted "
         "heredoc, then run it:\n"
-        f"{notify_heredoc(*route_args)}"
+        f"{heredoc}"
     )

--- a/container/lib/sessions.py
+++ b/container/lib/sessions.py
@@ -58,6 +58,7 @@ from execution_policy import (
 )
 from runtime_context import RuntimeContext
 from trust import ensure_claude_dir_trusted, ensure_codex_dir_trusted
+from notify_prompt import notify_reply_instruction
 
 _UUID_RE = re.compile(r'^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$')
 
@@ -971,16 +972,16 @@ def _adapter_context(data: dict) -> str:
         thread_ts = data.get("thread_ts", "")
         if channel and thread_ts:
             return (
-                f"\nThis session was started from Slack. Pass message text through a "
-                f"single-quoted heredoc to: notify --slack {channel} {thread_ts}\n"
+                "\nThis session was started from Slack.\n"
+                f"{notify_reply_instruction('--slack', channel, thread_ts)}\n"
                 f"Session link: {session_url}"
             )
     elif adapter == "telegram":
         chat_id = data.get("chat_id", "")
         if chat_id:
             return (
-                f"\nThis session was started from Telegram. Pass message text through a "
-                f"single-quoted heredoc to: notify --telegram {chat_id}\n"
+                "\nThis session was started from Telegram.\n"
+                f"{notify_reply_instruction('--telegram', chat_id)}\n"
                 f"Session link: {session_url}"
             )
     return ""

--- a/container/lib/sessions.py
+++ b/container/lib/sessions.py
@@ -971,16 +971,16 @@ def _adapter_context(data: dict) -> str:
         thread_ts = data.get("thread_ts", "")
         if channel and thread_ts:
             return (
-                f"\nThis session was started from Slack. Send messages with: "
-                f'notify --slack {channel} {thread_ts} "your message"\n'
+                f"\nThis session was started from Slack. Pass message text on stdin to: "
+                f"notify --slack {channel} {thread_ts} --stdin\n"
                 f"Session link: {session_url}"
             )
     elif adapter == "telegram":
         chat_id = data.get("chat_id", "")
         if chat_id:
             return (
-                f"\nThis session was started from Telegram. Send messages with: "
-                f'notify --telegram {chat_id} "your message"\n'
+                f"\nThis session was started from Telegram. Pass message text on stdin to: "
+                f"notify --telegram {chat_id} --stdin\n"
                 f"Session link: {session_url}"
             )
     return ""

--- a/container/lib/sessions.py
+++ b/container/lib/sessions.py
@@ -971,16 +971,16 @@ def _adapter_context(data: dict) -> str:
         thread_ts = data.get("thread_ts", "")
         if channel and thread_ts:
             return (
-                f"\nThis session was started from Slack. Pass message text on stdin to: "
-                f"notify --slack {channel} {thread_ts} --stdin\n"
+                f"\nThis session was started from Slack. Pass message text through a "
+                f"single-quoted heredoc to: notify --slack {channel} {thread_ts}\n"
                 f"Session link: {session_url}"
             )
     elif adapter == "telegram":
         chat_id = data.get("chat_id", "")
         if chat_id:
             return (
-                f"\nThis session was started from Telegram. Pass message text on stdin to: "
-                f"notify --telegram {chat_id} --stdin\n"
+                f"\nThis session was started from Telegram. Pass message text through a "
+                f"single-quoted heredoc to: notify --telegram {chat_id}\n"
                 f"Session link: {session_url}"
             )
     return ""

--- a/container/lib/wolts.py
+++ b/container/lib/wolts.py
@@ -312,10 +312,13 @@ identity, memory, and site. The platform provides shared infrastructure; you pro
 
 Use the `notify` command to message the user on Telegram/Slack:
 ```bash
-notify --stdin
+notify <<'WOLTSPACE_NOTIFY_7F3A91C2'
+your message here
+WOLTSPACE_NOTIFY_7F3A91C2
 ```
-Pass the exact message through the execution tool's stdin input. Never embed
-generated or user-controlled message text in a shell command.
+Use a fresh random delimiter each time. Keep the opening delimiter single-quoted
+and the closing delimiter on a line by itself so the shell treats the message
+body literally. Never pass message text as a command argument.
 
 ## Your Site
 

--- a/container/lib/wolts.py
+++ b/container/lib/wolts.py
@@ -312,8 +312,10 @@ identity, memory, and site. The platform provides shared infrastructure; you pro
 
 Use the `notify` command to message the user on Telegram/Slack:
 ```bash
-notify "your message here"
+notify --stdin
 ```
+Pass the exact message through the execution tool's stdin input. Never embed
+generated or user-controlled message text in a shell command.
 
 ## Your Site
 

--- a/container/lib/wolts.py
+++ b/container/lib/wolts.py
@@ -312,9 +312,9 @@ identity, memory, and site. The platform provides shared infrastructure; you pro
 
 Use the `notify` command to message the user on Telegram/Slack:
 ```bash
-notify <<'WOLTSPACE_NOTIFY_7F3A91C2'
+notify <<'WOLTSPACE_NOTIFY_<16_RANDOM_HEX>'
 your message here
-WOLTSPACE_NOTIFY_7F3A91C2
+WOLTSPACE_NOTIFY_<16_RANDOM_HEX>
 ```
 Use a fresh random delimiter each time. Keep the opening delimiter single-quoted
 and the closing delimiter on a line by itself so the shell treats the message

--- a/container/skills/notify/SKILL.md
+++ b/container/skills/notify/SKILL.md
@@ -28,8 +28,10 @@ WOLTSPACE_NOTIFY_A6C195E4
 
 Use a fresh random suffix in the delimiter for every message, and quote the
 opening delimiter exactly as shown. Put the closing delimiter on a line by
-itself. A single-quoted heredoc passes its body literally: the shell does not
-expand backticks, `$()`, variables, quotes, or other metacharacters.
+itself. Never paste the bare closing delimiter on its own line into the message
+body, because that would end the heredoc early. A single-quoted heredoc passes
+its body literally: the shell does not expand backticks, `$()`, variables,
+quotes, or other metacharacters.
 
 `notify` accepts no message argument. This keeps message text out of the shell
 command itself on every harness.

--- a/container/skills/notify/SKILL.md
+++ b/container/skills/notify/SKILL.md
@@ -40,15 +40,24 @@ When your session receives a message from Slack or Telegram, the prepended conte
 
 ```
 [slack message from human, channel=C0123ABC, thread=1711234567.890123]: hey do the thing
-Reply using a single-quoted heredoc with: notify --slack C0123ABC 1711234567.890123
+Reply by replacing YOUR_REPLY in this exact single-quoted heredoc, then run it:
+notify --slack C0123ABC 1711234567.890123 <<'WOLTSPACE_NOTIFY_4D8E20B1'
+YOUR_REPLY
+WOLTSPACE_NOTIFY_4D8E20B1
 ```
 
 ```
 [telegram message from human, chat_id=98765432]: hey do the thing
-Reply using a single-quoted heredoc with: notify --telegram 98765432
+Reply by replacing YOUR_REPLY in this exact single-quoted heredoc, then run it:
+notify --telegram 98765432 <<'WOLTSPACE_NOTIFY_A6C195E4'
+YOUR_REPLY
+WOLTSPACE_NOTIFY_A6C195E4
 ```
 
-**Use the exact command from the prepended context.** This ensures your reply goes to the right place — the specific Slack thread or Telegram chat the message came from.
+**Use the exact heredoc from the prepended context and replace only `YOUR_REPLY`.**
+Woltspace generates a fresh delimiter every time. This ensures the message stays
+literal and goes to the specific Slack thread or Telegram chat it came from;
+you do not need to load this skill merely to reply.
 
 ## When to use it
 

--- a/container/skills/notify/SKILL.md
+++ b/container/skills/notify/SKILL.md
@@ -11,22 +11,28 @@ Sessions can send messages back to the user at any time. Use this when you finis
 
 ```bash
 # Default — auto-routes via session registry, falls back to Telegram
-notify --stdin
+notify <<'WOLTSPACE_NOTIFY_7F3A91C2'
+your message here
+WOLTSPACE_NOTIFY_7F3A91C2
 
 # Explicit Slack — send to a specific Slack channel + thread
-notify --slack CHANNEL THREAD_TS --stdin
+notify --slack CHANNEL THREAD_TS <<'WOLTSPACE_NOTIFY_4D8E20B1'
+your message here
+WOLTSPACE_NOTIFY_4D8E20B1
 
 # Explicit Telegram — send to a specific Telegram chat
-notify --telegram CHAT_ID --stdin
+notify --telegram CHAT_ID <<'WOLTSPACE_NOTIFY_A6C195E4'
+your message here
+WOLTSPACE_NOTIFY_A6C195E4
 ```
 
-Start the command, then pass the exact message through your execution tool's
-stdin input. Never interpolate generated or user-controlled message text into a
-shell command string: the shell would expand backticks, `$()`, quotes, and
-other metacharacters before `notify` receives them.
+Use a fresh random suffix in the delimiter for every message, and quote the
+opening delimiter exactly as shown. Put the closing delimiter on a line by
+itself. A single-quoted heredoc passes its body literally: the shell does not
+expand backticks, `$()`, variables, quotes, or other metacharacters.
 
-The legacy `notify "static message"` form remains available for compatibility,
-but do not use it for generated or user-controlled text.
+`notify` accepts no message argument. This keeps message text out of the shell
+command itself on every harness.
 
 ## Explicit routing
 
@@ -34,12 +40,12 @@ When your session receives a message from Slack or Telegram, the prepended conte
 
 ```
 [slack message from human, channel=C0123ABC, thread=1711234567.890123]: hey do the thing
-Reply by passing message text on stdin to: notify --slack C0123ABC 1711234567.890123 --stdin
+Reply using a single-quoted heredoc with: notify --slack C0123ABC 1711234567.890123
 ```
 
 ```
 [telegram message from human, chat_id=98765432]: hey do the thing
-Reply by passing message text on stdin to: notify --telegram 98765432 --stdin
+Reply using a single-quoted heredoc with: notify --telegram 98765432
 ```
 
 **Use the exact command from the prepended context.** This ensures your reply goes to the right place — the specific Slack thread or Telegram chat the message came from.
@@ -55,16 +61,24 @@ Reply by passing message text on stdin to: notify --telegram 98765432 --stdin
 
 ```bash
 # Task done
-notify --stdin
+notify <<'WOLTSPACE_NOTIFY_08D741BE'
+playlist built — 12 tracks, Karkwa + kin. https://open.spotify.com/playlist/xyz
+WOLTSPACE_NOTIFY_08D741BE
 
 # Blocked
-notify --stdin
+notify <<'WOLTSPACE_NOTIFY_B2A563F9'
+hit a rate limit on Spotify API — should I retry in 30s or skip?
+WOLTSPACE_NOTIFY_B2A563F9
 
 # Explicit Slack reply
-notify --slack C0123ABC 1711234567.890123 --stdin
+notify --slack C0123ABC 1711234567.890123 <<'WOLTSPACE_NOTIFY_94C8D130'
+done — PR opened at github.com/...
+WOLTSPACE_NOTIFY_94C8D130
 
 # Explicit Telegram reply
-notify --telegram 98765432 --stdin
+notify --telegram 98765432 <<'WOLTSPACE_NOTIFY_E70A249C'
+found the bug, fix pushed
+WOLTSPACE_NOTIFY_E70A249C
 ```
 
 ## How it works

--- a/container/skills/notify/SKILL.md
+++ b/container/skills/notify/SKILL.md
@@ -11,14 +11,22 @@ Sessions can send messages back to the user at any time. Use this when you finis
 
 ```bash
 # Default — auto-routes via session registry, falls back to Telegram
-notify "your message here"
+notify --stdin
 
 # Explicit Slack — send to a specific Slack channel + thread
-notify --slack CHANNEL THREAD_TS "your message here"
+notify --slack CHANNEL THREAD_TS --stdin
 
 # Explicit Telegram — send to a specific Telegram chat
-notify --telegram CHAT_ID "your message here"
+notify --telegram CHAT_ID --stdin
 ```
+
+Start the command, then pass the exact message through your execution tool's
+stdin input. Never interpolate generated or user-controlled message text into a
+shell command string: the shell would expand backticks, `$()`, quotes, and
+other metacharacters before `notify` receives them.
+
+The legacy `notify "static message"` form remains available for compatibility,
+but do not use it for generated or user-controlled text.
 
 ## Explicit routing
 
@@ -26,12 +34,12 @@ When your session receives a message from Slack or Telegram, the prepended conte
 
 ```
 [slack message from human, channel=C0123ABC, thread=1711234567.890123]: hey do the thing
-Reply back to them with: notify --slack C0123ABC 1711234567.890123 "your message"
+Reply by passing message text on stdin to: notify --slack C0123ABC 1711234567.890123 --stdin
 ```
 
 ```
 [telegram message from human, chat_id=98765432]: hey do the thing
-Reply back to them with: notify --telegram 98765432 "your message"
+Reply by passing message text on stdin to: notify --telegram 98765432 --stdin
 ```
 
 **Use the exact command from the prepended context.** This ensures your reply goes to the right place — the specific Slack thread or Telegram chat the message came from.
@@ -47,16 +55,16 @@ Reply back to them with: notify --telegram 98765432 "your message"
 
 ```bash
 # Task done
-notify "playlist built — 12 tracks, Karkwa + kin. https://open.spotify.com/playlist/xyz"
+notify --stdin
 
 # Blocked
-notify "hit a rate limit on Spotify API — should I retry in 30s or skip?"
+notify --stdin
 
 # Explicit Slack reply
-notify --slack C0123ABC 1711234567.890123 "done — PR opened at github.com/..."
+notify --slack C0123ABC 1711234567.890123 --stdin
 
 # Explicit Telegram reply
-notify --telegram 98765432 "found the bug, fix pushed"
+notify --telegram 98765432 --stdin
 ```
 
 ## How it works

--- a/container/skills/start-chat/modes/lodge.md
+++ b/container/skills/start-chat/modes/lodge.md
@@ -6,7 +6,7 @@ You were started from the lodge — the woltspace home page. The developer click
 
 The developer is watching this terminal directly — you do NOT need to use `notify`. Just talk normally in the terminal. They can see everything you type and do.
 
-If they step away and ask you to notify them, then pass the message on stdin to `notify --stdin` — but default to terminal conversation.
+If they step away and ask you to notify them, then pass the message to `notify` with a single-quoted heredoc and a fresh random delimiter — but default to terminal conversation.
 
 ## Viewport
 

--- a/container/skills/start-chat/modes/lodge.md
+++ b/container/skills/start-chat/modes/lodge.md
@@ -6,7 +6,7 @@ You were started from the lodge — the woltspace home page. The developer click
 
 The developer is watching this terminal directly — you do NOT need to use `notify`. Just talk normally in the terminal. They can see everything you type and do.
 
-If they step away and ask you to notify them, then use `notify "your message"` — but default to terminal conversation.
+If they step away and ask you to notify them, then pass the message on stdin to `notify --stdin` — but default to terminal conversation.
 
 ## Viewport
 
@@ -17,4 +17,3 @@ Use `push-view /wolt/<your-wolt-name>/site/page.html` — that's all you need. Y
 ## Scheduling
 
 You can schedule recurring or one-off tasks via the woltspace wolf skill. Your crons live in your own `wolt/wolf.json`.
-

--- a/container/skills/start-chat/modes/slack.md
+++ b/container/skills/start-chat/modes/slack.md
@@ -6,10 +6,12 @@ Think of it like messaging a dev colleague on Slack: you do the work here, then 
 
 ## Notifications
 
-Use `notify --stdin` and pass the message through your execution tool's stdin input. When the prepended message context includes Slack channel and thread IDs, use the explicit form:
+Pass messages to `notify` with a single-quoted heredoc and a fresh random delimiter. When the prepended message context includes Slack channel and thread IDs, use the explicit form:
 
 ```bash
-notify --slack CHANNEL THREAD_TS --stdin
+notify --slack CHANNEL THREAD_TS <<'WOLTSPACE_NOTIFY_7F3A91C2'
+your message here
+WOLTSPACE_NOTIFY_7F3A91C2
 ```
 
 This ensures your reply lands in the right Slack thread. The prepended context will tell you exactly which flags to use.
@@ -30,7 +32,7 @@ Use `push-view /your-page.html` — that's all you need. Load the woltspace view
 
 Rule of thumb: if you created an artifact someone would want to look at, push it to the viewport.
 
-**IMPORTANT**: To send a message to the developer, ALWAYS pass it on stdin to `notify --stdin`. Never embed generated or user-controlled text in a shell command, and never call the notify endpoint via curl directly — the notify script handles session routing, emoji prefix, and delivery correctly.
+**IMPORTANT**: To send a message to the developer, ALWAYS pass it to `notify` in a single-quoted heredoc with a fresh random delimiter. Never pass message text as a command argument, and never call the notify endpoint via curl directly — the notify script handles session routing, emoji prefix, and delivery correctly.
 
 ## Scheduling
 

--- a/container/skills/start-chat/modes/slack.md
+++ b/container/skills/start-chat/modes/slack.md
@@ -6,10 +6,10 @@ Think of it like messaging a dev colleague on Slack: you do the work here, then 
 
 ## Notifications
 
-Use `notify "your message"` to send messages. When the prepended message context includes Slack channel and thread IDs, use the explicit form:
+Use `notify --stdin` and pass the message through your execution tool's stdin input. When the prepended message context includes Slack channel and thread IDs, use the explicit form:
 
 ```bash
-notify --slack CHANNEL THREAD_TS "your message"
+notify --slack CHANNEL THREAD_TS --stdin
 ```
 
 This ensures your reply lands in the right Slack thread. The prepended context will tell you exactly which flags to use.
@@ -30,9 +30,8 @@ Use `push-view /your-page.html` — that's all you need. Load the woltspace view
 
 Rule of thumb: if you created an artifact someone would want to look at, push it to the viewport.
 
-**IMPORTANT**: To send a message to the developer, ALWAYS use `notify "your message"`. Never call the notify endpoint via curl directly — the notify script handles session routing, emoji prefix, and delivery correctly.
+**IMPORTANT**: To send a message to the developer, ALWAYS pass it on stdin to `notify --stdin`. Never embed generated or user-controlled text in a shell command, and never call the notify endpoint via curl directly — the notify script handles session routing, emoji prefix, and delivery correctly.
 
 ## Scheduling
 
 You can schedule recurring or one-off tasks via the woltspace wolf skill. Your crons live in your own `wolt/wolf.json`.
-

--- a/container/skills/start-chat/modes/slack.md
+++ b/container/skills/start-chat/modes/slack.md
@@ -14,7 +14,9 @@ your message here
 WOLTSPACE_NOTIFY_7F3A91C2
 ```
 
-This ensures your reply lands in the right Slack thread. The prepended context will tell you exactly which flags to use.
+This ensures your reply lands in the right Slack thread. Each incoming message
+includes a complete heredoc with the correct route and a fresh delimiter; replace
+only `YOUR_REPLY` and run it. You do not need to load the notify skill first.
 
 **When you start**: one-liner ack. "on it — reviewing the loop" or "got it, digging in."
 

--- a/container/skills/start-chat/modes/telegram.md
+++ b/container/skills/start-chat/modes/telegram.md
@@ -6,10 +6,10 @@ Think of it like messaging a dev colleague on Telegram: you do the work here, th
 
 ## Notifications
 
-Use `notify "your message"` to send messages. When the prepended message context includes a Telegram chat ID, use the explicit form:
+Use `notify --stdin` and pass the message through your execution tool's stdin input. When the prepended message context includes a Telegram chat ID, use the explicit form:
 
 ```bash
-notify --telegram CHAT_ID "your message"
+notify --telegram CHAT_ID --stdin
 ```
 
 This ensures your reply lands in the right chat. The prepended context will tell you exactly which flags to use.
@@ -30,9 +30,8 @@ Use `push-view /your-page.html` — that's all you need. Load the woltspace view
 
 Rule of thumb: if you created an artifact someone would want to look at, push it to the viewport.
 
-**IMPORTANT**: To send a message to the developer, ALWAYS use `notify "your message"`. Never call the notify endpoint via curl directly — the notify script handles session routing, emoji prefix, and Telegram delivery correctly.
+**IMPORTANT**: To send a message to the developer, ALWAYS pass it on stdin to `notify --stdin`. Never embed generated or user-controlled text in a shell command, and never call the notify endpoint via curl directly — the notify script handles session routing, emoji prefix, and Telegram delivery correctly.
 
 ## Scheduling
 
 You can schedule recurring or one-off tasks via the woltspace wolf skill. Your crons live in your own `wolt/wolf.json`.
-

--- a/container/skills/start-chat/modes/telegram.md
+++ b/container/skills/start-chat/modes/telegram.md
@@ -6,10 +6,12 @@ Think of it like messaging a dev colleague on Telegram: you do the work here, th
 
 ## Notifications
 
-Use `notify --stdin` and pass the message through your execution tool's stdin input. When the prepended message context includes a Telegram chat ID, use the explicit form:
+Pass messages to `notify` with a single-quoted heredoc and a fresh random delimiter. When the prepended message context includes a Telegram chat ID, use the explicit form:
 
 ```bash
-notify --telegram CHAT_ID --stdin
+notify --telegram CHAT_ID <<'WOLTSPACE_NOTIFY_7F3A91C2'
+your message here
+WOLTSPACE_NOTIFY_7F3A91C2
 ```
 
 This ensures your reply lands in the right chat. The prepended context will tell you exactly which flags to use.
@@ -30,7 +32,7 @@ Use `push-view /your-page.html` — that's all you need. Load the woltspace view
 
 Rule of thumb: if you created an artifact someone would want to look at, push it to the viewport.
 
-**IMPORTANT**: To send a message to the developer, ALWAYS pass it on stdin to `notify --stdin`. Never embed generated or user-controlled text in a shell command, and never call the notify endpoint via curl directly — the notify script handles session routing, emoji prefix, and Telegram delivery correctly.
+**IMPORTANT**: To send a message to the developer, ALWAYS pass it to `notify` in a single-quoted heredoc with a fresh random delimiter. Never pass message text as a command argument, and never call the notify endpoint via curl directly — the notify script handles session routing, emoji prefix, and Telegram delivery correctly.
 
 ## Scheduling
 

--- a/container/skills/start-chat/modes/telegram.md
+++ b/container/skills/start-chat/modes/telegram.md
@@ -14,7 +14,9 @@ your message here
 WOLTSPACE_NOTIFY_7F3A91C2
 ```
 
-This ensures your reply lands in the right chat. The prepended context will tell you exactly which flags to use.
+This ensures your reply lands in the right chat. Each incoming message includes
+a complete heredoc with the correct route and a fresh delimiter; replace only
+`YOUR_REPLY` and run it. You do not need to load the notify skill first.
 
 **When you start**: one-liner ack. "on it — reviewing the loop" or "got it, digging in."
 

--- a/template/CLAUDE.md
+++ b/template/CLAUDE.md
@@ -16,8 +16,13 @@ identity, memory, and site. The platform provides shared infrastructure; you pro
 
 Use the `notify` command to message the user on Telegram/Slack:
 ```bash
-notify "your message here"
+notify <<'WOLTSPACE_NOTIFY_7F3A91C2'
+your message here
+WOLTSPACE_NOTIFY_7F3A91C2
 ```
+Use a fresh random delimiter each time. Keep the opening delimiter single-quoted
+and the closing delimiter on a line by itself so the shell treats the message
+body literally. Never pass message text as a command argument.
 
 ## Your Site
 

--- a/test/test_notify_cli.py
+++ b/test/test_notify_cli.py
@@ -1,6 +1,7 @@
 import json
 import os
 from pathlib import Path
+import shlex
 import subprocess
 
 
@@ -51,7 +52,7 @@ def test_stdin_preserves_shell_metacharacters_and_multiline_text(tmp_path):
     )
 
     result = subprocess.run(
-        [NOTIFY, "--telegram", "-100123", "--stdin"],
+        [NOTIFY, "--telegram", "-100123"],
         input=message,
         text=True,
         capture_output=True,
@@ -65,18 +66,44 @@ def test_stdin_preserves_shell_metacharacters_and_multiline_text(tmp_path):
     assert payload["message"] == f"🦫 testwolt: {message}"
 
 
-def test_legacy_single_argument_form_remains_supported(tmp_path):
+def test_quoted_heredoc_keeps_command_looking_text_literal(tmp_path):
     env, capture = _environment(tmp_path)
+    marker = tmp_path / "must-not-exist"
+    delimiter = "WOLTSPACE_NOTIFY_7F3A91C2"
+    message = (
+        f"do not run `touch {marker}` or $(touch {marker})\n"
+        'formatting stays intact: *bold-ish* `code` "quotes"\n'
+    )
+    command = (
+        f"{shlex.quote(str(NOTIFY))} --telegram 123 <<'{delimiter}'\n"
+        f"{message}{delimiter}\n"
+    )
 
     result = subprocess.run(
-        [NOTIFY, "legacy static message"],
+        ["sh", "-c", command],
         text=True,
         capture_output=True,
         env=env,
     )
 
     assert result.returncode == 0, result.stderr
-    assert json.loads(capture.read_text())["message"] == "🦫 testwolt: legacy static message"
+    assert not marker.exists()
+    assert json.loads(capture.read_text())["message"] == f"🦫 testwolt: {message}"
+
+
+def test_rejects_message_arguments_without_sending(tmp_path):
+    env, capture = _environment(tmp_path)
+
+    result = subprocess.run(
+        [NOTIFY, "legacy message argument"],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 2
+    assert "message arguments are not supported" in result.stderr
+    assert not capture.exists()
 
 
 def test_help_prints_usage_without_sending(tmp_path):
@@ -94,7 +121,7 @@ def test_help_prints_usage_without_sending(tmp_path):
     assert not capture.exists()
 
 
-def test_rejects_extra_message_arguments_without_sending(tmp_path):
+def test_rejects_extra_arguments_without_sending(tmp_path):
     env, capture = _environment(tmp_path)
 
     result = subprocess.run(
@@ -105,7 +132,7 @@ def test_rejects_extra_message_arguments_without_sending(tmp_path):
     )
 
     assert result.returncode == 2
-    assert "expected exactly one message or --stdin" in result.stderr
+    assert "message arguments are not supported" in result.stderr
     assert not capture.exists()
 
 
@@ -113,14 +140,14 @@ def test_rejects_empty_stdin_and_invalid_chat_id(tmp_path):
     env, capture = _environment(tmp_path)
 
     empty = subprocess.run(
-        [NOTIFY, "--stdin"],
+        [NOTIFY],
         input="",
         text=True,
         capture_output=True,
         env=env,
     )
     invalid_chat = subprocess.run(
-        [NOTIFY, "--telegram", "not-a-chat", "--stdin"],
+        [NOTIFY, "--telegram", "not-a-chat"],
         input="hello",
         text=True,
         capture_output=True,
@@ -132,7 +159,7 @@ def test_rejects_empty_stdin_and_invalid_chat_id(tmp_path):
     assert not capture.exists()
 
 
-def test_session_context_recommends_stdin_for_explicit_routes():
+def test_session_context_recommends_quoted_heredocs_for_explicit_routes():
     from sessions import _adapter_context
 
     telegram = _adapter_context(
@@ -151,6 +178,6 @@ def test_session_context_recommends_stdin_for_explicit_routes():
         }
     )
 
-    assert "notify --telegram 123 --stdin" in telegram
-    assert "notify --slack C123 123.456 --stdin" in slack
+    assert "single-quoted heredoc to: notify --telegram 123" in telegram
+    assert "single-quoted heredoc to: notify --slack C123 123.456" in slack
     assert '"your message"' not in telegram + slack

--- a/test/test_notify_cli.py
+++ b/test/test_notify_cli.py
@@ -1,8 +1,10 @@
 import json
 import os
 from pathlib import Path
-import shlex
+import re
+import runpy
 import subprocess
+from unittest.mock import patch
 
 
 ROOT = Path(__file__).parents[1]
@@ -28,6 +30,7 @@ printf '%s\\n' '{\"ok\":true,\"adapter\":\"telegram\"}'
 """
     )
     curl.chmod(0o755)
+    (bin_dir / "notify").symlink_to(NOTIFY)
 
     env = os.environ.copy()
     env.update(
@@ -67,16 +70,17 @@ def test_stdin_preserves_shell_metacharacters_and_multiline_text(tmp_path):
 
 
 def test_quoted_heredoc_keeps_command_looking_text_literal(tmp_path):
+    from notify_prompt import notify_heredoc
+
     env, capture = _environment(tmp_path)
     marker = tmp_path / "must-not-exist"
-    delimiter = "WOLTSPACE_NOTIFY_7F3A91C2"
+    delimiter = "WOLTSPACE_NOTIFY_7F3A91C2D4E5B607"
     message = (
         f"do not run `touch {marker}` or $(touch {marker})\n"
         'formatting stays intact: *bold-ish* `code` "quotes"\n'
     )
-    command = (
-        f"{shlex.quote(str(NOTIFY))} --telegram 123 <<'{delimiter}'\n"
-        f"{message}{delimiter}\n"
+    command = notify_heredoc(
+        "--telegram", "123", body=message, delimiter=delimiter
     )
 
     result = subprocess.run(
@@ -89,6 +93,32 @@ def test_quoted_heredoc_keeps_command_looking_text_literal(tmp_path):
     assert result.returncode == 0, result.stderr
     assert not marker.exists()
     assert json.loads(capture.read_text())["message"] == f"🦫 testwolt: {message}"
+
+
+def test_notify_prompt_uses_fresh_delimiter_and_quotes_route_arguments():
+    from notify_prompt import notify_heredoc
+
+    first = notify_heredoc("--slack", "channel with spaces", "123.456")
+    second = notify_heredoc("--slack", "channel with spaces", "123.456")
+
+    assert first != second
+    assert "notify --slack 'channel with spaces' 123.456" in first
+
+
+def test_create_creature_wolt_passes_message_on_stdin():
+    script = ROOT / "container" / "bin" / "create-creature-wolt"
+    notify = runpy.run_path(str(script))["_notify"]
+
+    with patch("subprocess.run") as run:
+        notify("singleton changed")
+
+    run.assert_called_once_with(
+        ["notify"],
+        input="singleton changed",
+        text=True,
+        timeout=10,
+        capture_output=True,
+    )
 
 
 def test_rejects_message_arguments_without_sending(tmp_path):
@@ -159,7 +189,7 @@ def test_rejects_empty_stdin_and_invalid_chat_id(tmp_path):
     assert not capture.exists()
 
 
-def test_session_context_recommends_quoted_heredocs_for_explicit_routes():
+def test_session_context_inlines_complete_heredocs_for_explicit_routes():
     from sessions import _adapter_context
 
     telegram = _adapter_context(
@@ -178,6 +208,18 @@ def test_session_context_recommends_quoted_heredocs_for_explicit_routes():
         }
     )
 
-    assert "single-quoted heredoc to: notify --telegram 123" in telegram
-    assert "single-quoted heredoc to: notify --slack C123 123.456" in slack
+    telegram_match = re.search(
+        r"notify --telegram 123 <<'(WOLTSPACE_NOTIFY_[A-F0-9]{16})'\n"
+        r"YOUR_REPLY\n\1",
+        telegram,
+    )
+    slack_match = re.search(
+        r"notify --slack C123 123[.]456 <<'(WOLTSPACE_NOTIFY_[A-F0-9]{16})'\n"
+        r"YOUR_REPLY\n\1",
+        slack,
+    )
+
+    assert telegram_match
+    assert slack_match
+    assert "replacing YOUR_REPLY" in telegram + slack
     assert '"your message"' not in telegram + slack

--- a/test/test_notify_cli.py
+++ b/test/test_notify_cli.py
@@ -6,6 +6,8 @@ import runpy
 import subprocess
 from unittest.mock import patch
 
+import pytest
+
 
 ROOT = Path(__file__).parents[1]
 NOTIFY = ROOT / "container" / "bin" / "notify"
@@ -95,14 +97,21 @@ def test_quoted_heredoc_keeps_command_looking_text_literal(tmp_path):
     assert json.loads(capture.read_text())["message"] == f"🦫 testwolt: {message}"
 
 
-def test_notify_prompt_uses_fresh_delimiter_and_quotes_route_arguments():
+def test_notify_prompt_uses_fresh_delimiter_for_valid_route():
     from notify_prompt import notify_heredoc
 
-    first = notify_heredoc("--slack", "channel with spaces", "123.456")
-    second = notify_heredoc("--slack", "channel with spaces", "123.456")
+    first = notify_heredoc("--slack", "C0123ABC", "123.456")
+    second = notify_heredoc("--slack", "C0123ABC", "123.456")
 
     assert first != second
-    assert "notify --slack 'channel with spaces' 123.456" in first
+    assert "notify --slack C0123ABC 123.456" in first
+
+
+def test_notify_prompt_rejects_channel_the_cli_would_reject():
+    from notify_prompt import notify_heredoc
+
+    with pytest.raises(ValueError, match="channel has invalid characters"):
+        notify_heredoc("--slack", "channel with spaces", "123.456")
 
 
 def test_create_creature_wolt_passes_message_on_stdin():
@@ -134,6 +143,49 @@ def test_rejects_message_arguments_without_sending(tmp_path):
     assert result.returncode == 2
     assert "message arguments are not supported" in result.stderr
     assert not capture.exists()
+
+
+@pytest.mark.parametrize(
+    ("route_args", "expected_route"),
+    [
+        (["--telegram", "-100123"], {"adapter": "telegram", "chat_id": "-100123"}),
+        (
+            ["--slack", "C0123ABC", "123.456"],
+            {
+                "adapter": "slack",
+                "channel": "C0123ABC",
+                "thread_ts": "123.456",
+            },
+        ),
+    ],
+)
+def test_rejected_message_prints_executable_route_preserving_recovery(
+    tmp_path, route_args, expected_route
+):
+    env, capture = _environment(tmp_path)
+    message = 'literal `whoami` $(id) $HOME * "quotes"\n\nlast line'
+
+    rejected = subprocess.run(
+        [NOTIFY, *route_args, message],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert rejected.returncode == 2
+    recovery = rejected.stderr.split("Run this instead:\n\n", 1)[1]
+    rerun = subprocess.run(
+        ["sh", "-c", recovery],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert rerun.returncode == 0, rerun.stderr
+    payload = json.loads(capture.read_text())
+    for key, value in expected_route.items():
+        assert payload[key] == value
+    assert payload["message"] == f"🦫 testwolt: {message}\n"
 
 
 def test_help_prints_usage_without_sending(tmp_path):

--- a/test/test_notify_cli.py
+++ b/test/test_notify_cli.py
@@ -1,0 +1,156 @@
+import json
+import os
+from pathlib import Path
+import subprocess
+
+
+ROOT = Path(__file__).parents[1]
+NOTIFY = ROOT / "container" / "bin" / "notify"
+
+
+def _environment(tmp_path: Path) -> tuple[dict[str, str], Path]:
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    capture = tmp_path / "payload.json"
+    curl = bin_dir / "curl"
+    curl.write_text(
+        """#!/bin/bash
+while [ \"$#\" -gt 0 ]; do
+  if [ \"$1\" = \"-d\" ]; then
+    printf '%s' \"$2\" > \"$NOTIFY_CAPTURE\"
+    shift 2
+  else
+    shift
+  fi
+done
+printf '%s\\n' '{\"ok\":true,\"adapter\":\"telegram\"}'
+"""
+    )
+    curl.chmod(0o755)
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "PATH": f"{bin_dir}:{env['PATH']}",
+            "NOTIFY_CAPTURE": str(capture),
+            "WOLTSPACE_API": "http://notify.test",
+            "WOLTSPACE_WOLT_NAME": "testwolt",
+            "WOLTSPACE_WOLT_SESSION": "",
+            "WOLT_SESSION": "",
+        }
+    )
+    return env, capture
+
+
+def test_stdin_preserves_shell_metacharacters_and_multiline_text(tmp_path):
+    env, capture = _environment(tmp_path)
+    marker = tmp_path / "must-not-exist"
+    message = (
+        f"literal `touch {marker}` and $(touch {marker})\n"
+        'quotes: "double" and \'single\'; wildcard: *; dollar: $HOME\n\n'
+    )
+
+    result = subprocess.run(
+        [NOTIFY, "--telegram", "-100123", "--stdin"],
+        input=message,
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not marker.exists()
+    payload = json.loads(capture.read_text())
+    assert payload["chat_id"] == "-100123"
+    assert payload["message"] == f"🦫 testwolt: {message}"
+
+
+def test_legacy_single_argument_form_remains_supported(tmp_path):
+    env, capture = _environment(tmp_path)
+
+    result = subprocess.run(
+        [NOTIFY, "legacy static message"],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert json.loads(capture.read_text())["message"] == "🦫 testwolt: legacy static message"
+
+
+def test_help_prints_usage_without_sending(tmp_path):
+    env, capture = _environment(tmp_path)
+
+    result = subprocess.run(
+        [NOTIFY, "--help"],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 0
+    assert "notify --telegram CHAT_ID" in result.stdout
+    assert not capture.exists()
+
+
+def test_rejects_extra_message_arguments_without_sending(tmp_path):
+    env, capture = _environment(tmp_path)
+
+    result = subprocess.run(
+        [NOTIFY, "--telegram", "123", "one", "two"],
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert result.returncode == 2
+    assert "expected exactly one message or --stdin" in result.stderr
+    assert not capture.exists()
+
+
+def test_rejects_empty_stdin_and_invalid_chat_id(tmp_path):
+    env, capture = _environment(tmp_path)
+
+    empty = subprocess.run(
+        [NOTIFY, "--stdin"],
+        input="",
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+    invalid_chat = subprocess.run(
+        [NOTIFY, "--telegram", "not-a-chat", "--stdin"],
+        input="hello",
+        text=True,
+        capture_output=True,
+        env=env,
+    )
+
+    assert empty.returncode == 2
+    assert invalid_chat.returncode == 2
+    assert not capture.exists()
+
+
+def test_session_context_recommends_stdin_for_explicit_routes():
+    from sessions import _adapter_context
+
+    telegram = _adapter_context(
+        {
+            "adapter": "telegram",
+            "chat_id": "123",
+            "session_url": "https://lodge.test/tui?session=one",
+        }
+    )
+    slack = _adapter_context(
+        {
+            "adapter": "slack",
+            "chat_id": "C123",
+            "thread_ts": "123.456",
+            "session_url": "https://lodge.test/tui?session=two",
+        }
+    )
+
+    assert "notify --telegram 123 --stdin" in telegram
+    assert "notify --slack C123 123.456 --stdin" in slack
+    assert '"your message"' not in telegram + slack

--- a/test/test_notify_cli.py
+++ b/test/test_notify_cli.py
@@ -114,6 +114,17 @@ def test_notify_prompt_rejects_channel_the_cli_would_reject():
         notify_heredoc("--slack", "channel with spaces", "123.456")
 
 
+def test_reply_instruction_falls_back_to_session_routing_for_invalid_route():
+    from notify_prompt import notify_reply_instruction
+
+    instruction = notify_reply_instruction(
+        "--slack", "channel with spaces", "123.456"
+    )
+
+    assert "\nnotify <<'WOLTSPACE_NOTIFY_" in instruction
+    assert "notify --slack" not in instruction
+
+
 def test_create_creature_wolt_passes_message_on_stdin():
     script = ROOT / "container" / "bin" / "create-creature-wolt"
     notify = runpy.run_path(str(script))["_notify"]
@@ -173,6 +184,7 @@ def test_rejected_message_prints_executable_route_preserving_recovery(
     )
 
     assert rejected.returncode == 2
+    assert "only what survived shell expansion" in rejected.stderr
     recovery = rejected.stderr.split("Run this instead:\n\n", 1)[1]
     rerun = subprocess.run(
         ["sh", "-c", recovery],
@@ -215,6 +227,7 @@ def test_rejects_extra_arguments_without_sending(tmp_path):
 
     assert result.returncode == 2
     assert "message arguments are not supported" in result.stderr
+    assert "Run this instead:" not in result.stderr
     assert not capture.exists()
 
 

--- a/test/test_wolts.py
+++ b/test/test_wolts.py
@@ -627,6 +627,8 @@ class TestSyncClaudeMdPlatformSection:
         content = (wolt / "CLAUDE.md").read_text()
         assert "OLD STUFF" not in content
         assert "DO NOT edit files outside" in content
+        assert "WOLTSPACE_NOTIFY_<16_RANDOM_HEX>" in content
+        assert "WOLTSPACE_NOTIFY_7F3A91C2" not in content
         assert "# Alpha" in content
 
     def test_skips_wolts_without_claude_md(self, tmp_path):


### PR DESCRIPTION
## Summary
- make standard input the only accepted message source for `notify`
- inject a complete, ready-to-run single-quoted heredoc into every Telegram and Slack session message
- generate a fresh high-entropy delimiter for every instruction and shell-quote routing arguments
- let a wolt reply by replacing only `YOUR_REPLY`, without loading or recalling the notify skill
- preserve multiline formatted text and trailing newlines literally
- validate routing arguments and reject message arguments, unknown options, invalid Telegram chat IDs, invalid Slack channels, and invalid thread timestamps
- migrate platform callers to stdin, including the update checker and singleton-creature notification path
- add real help output and align boot instructions, skills, templates, and architecture docs

## Why
Shells expand backticks, dollar-parenthesis, variables, and other syntax before a command receives a quoted argument. Generated message text must therefore never be embedded in the `notify` command line.

A single-quoted heredoc is standard shell behavior available to every supported harness. Its body is delivered on stdin without shell expansion, while the `notify` CLI remains the small platform-neutral wrapper around the existing Woltspace notify API.

The complete command is now supplied inline with each routed message. The wolt does not need to invoke a skill or remember heredoc syntax; it replaces the `YOUR_REPLY` line and runs the provided command.

## Safety properties
- the legacy message-argument form is removed rather than retained as a compatibility path
- generated message text stays outside the shell command line
- quoted heredoc bodies preserve Unicode, newlines, links, Markdown-like formatting, quotes, and command-looking text literally
- Woltspace generates a fresh delimiter per instruction so message content cannot predictably terminate the heredoc
- routing arguments are shell-quoted by one shared formatter
- API JSON encoding remains inside the notify wrapper

## Tests
- 9 focused CLI, generated-heredoc, prompt-context, and internal-caller tests passed
- 169 combined notify, session-lifecycle, skill-sync, adapter-offloading, and environment-contract tests passed; 1 skipped
- the generated heredoc is executed through POSIX `sh` with backticks, dollar-parenthesis, quotes, and multiline text, proving command-looking content remains literal
- Python compilation, Bash syntax, git diff checks, and wheel-content inspection passed
